### PR TITLE
feat: 投稿ができるように

### DIFF
--- a/app/components/postForm.tsx
+++ b/app/components/postForm.tsx
@@ -1,6 +1,6 @@
 import { useFetcher } from "@remix-run/react";
 import { useEffect, useState } from "react";
-import { action } from "~/routes/api.notes.create";
+import { action } from "~/routes/api.notes";
 
 export const PostForm = () => {
   const [content, setContent] = useState<string>("");
@@ -12,14 +12,15 @@ export const PostForm = () => {
 
     if (fetcher.state === "loading") {
       if ("error" in fetcher.data) {
-        return setErrorMessage(fetcher.data.error);
+        setErrorMessage(fetcher.data.error);
+        return;
       }
       setContent("");
     }
   }, [fetcher.state]);
 
   return (
-    <fetcher.Form method="post" action="/api/notes/create">
+    <fetcher.Form method="post" action="/api/notes">
       <textarea
         required
         name="content"

--- a/app/components/postForm.tsx
+++ b/app/components/postForm.tsx
@@ -1,0 +1,39 @@
+import { useFetcher } from "@remix-run/react";
+import { useEffect, useState } from "react";
+import { action } from "~/routes/api.notes.create";
+
+export const PostForm = () => {
+  const [content, setContent] = useState<string>("");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const fetcher = useFetcher<typeof action>();
+
+  useEffect(() => {
+    if (!fetcher.data) return;
+
+    if (fetcher.state === "loading") {
+      if ("error" in fetcher.data) {
+        return setErrorMessage(fetcher.data.error);
+      }
+      setContent("");
+    }
+  }, [fetcher.state]);
+
+  return (
+    <fetcher.Form method="post" action="/api/notes/create">
+      <textarea
+        required
+        name="content"
+        id="content"
+        value={content}
+        onChange={(event) => setContent(event.target.value)}
+      ></textarea>
+      <select id="visibility" name="visibility">
+        <option value="PUBLIC">Public</option>
+        <option value="HOME">Home</option>
+        <option value="FOLLOWERS">Followers</option>
+      </select>
+      <button type="submit">Submit</button>
+      <p>{errorMessage}</p>
+    </fetcher.Form>
+  );
+};

--- a/app/routes/api.notes.create.ts
+++ b/app/routes/api.notes.create.ts
@@ -1,0 +1,39 @@
+import { ActionFunctionArgs } from "@remix-run/cloudflare";
+import { accountCookie } from "~/lib/login";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const token = await accountCookie.parse(request.headers.get("Cookie"));
+  if (!token) {
+    return { error: "unauthorized" };
+  }
+
+  try {
+    const formData = await request.formData();
+    console.log(formData);
+    const res = await fetch("http://localhost:3000/notes", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        content: formData.get("content"),
+        visibility: formData.get("visibility"),
+        attachment_file_ids: [],
+        contents_warning_comment: "",
+      }),
+    });
+
+    if (!res.ok) {
+      const errorRes = (await res.json()) as { error: string };
+      return { error: errorRes.error };
+    }
+
+    return { status: "ok" };
+  } catch (e) {
+    if (e instanceof Error) {
+      return { error: e.message };
+    }
+    return { error: "unknown error" };
+  }
+};

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -9,7 +9,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   try {
     const formData = await request.formData();
-    console.log(formData);
     const res = await fetch("http://localhost:3000/notes", {
       method: "POST",
       headers: {

--- a/app/routes/timeline.tsx
+++ b/app/routes/timeline.tsx
@@ -5,6 +5,7 @@ import {
 } from "@remix-run/cloudflare";
 import { MetaFunction, useLoaderData } from "@remix-run/react";
 import { Note } from "~/components/note";
+import { PostForm } from "~/components/postForm";
 import { accountCookie } from "~/lib/login";
 import { parseToken, TokenPayload } from "~/lib/parseToken";
 import { fetchHomeTimeline, HomeTimelineResponse } from "~/lib/timeline";
@@ -55,6 +56,7 @@ export default function Timeline() {
 
   return (
     <div className={styles.noteContainer}>
+      <PostForm />
       {loaderData ? (
         loaderData.notes.map((note) => {
           const author = {


### PR DESCRIPTION
close #9 
## やったこと
- 投稿フォームの実装
  - タイムライン上部に投稿フォームを追加しました
  ![image](https://github.com/user-attachments/assets/45f66576-0dc3-49d6-8070-365e58a4981a)
- 公開範囲を設定できます(ダイレクトは別ページに実装する予定なので選択不可)
- 空文字列は送信できないようにしました(もう少しバリデーションしても良い気がする/バックエンドのバリデーションが不十分)
