### PR TITLE
fix: アカウントタイムラインでノートが0件のときはempty stateを表示する

### DIFF
--- a/app/routes/accounts.$id.tsx
+++ b/app/routes/accounts.$id.tsx
@@ -1,4 +1,9 @@
-import { LoaderFunctionArgs, MetaFunction, useLoaderData } from "react-router";
+import {
+  LoaderFunctionArgs,
+  MetaFunction,
+  useLoaderData,
+  useParams,
+} from "react-router";
 import { LoadMoreNoteButton } from "~/components/loadMoreNote";
 import { Note, NoteProps } from "~/components/note";
 import { account, AccountResponse, accountTimeline } from "~/lib/account";
@@ -75,6 +80,8 @@ export default function Account() {
       loggedInAccountID: data.account.id,
     })
   );
+  const params = useParams();
+  const isThisAccountSelf = !!params.id && params.id === data.account.name;
 
   return (
     <>
@@ -99,7 +106,15 @@ export default function Account() {
         </div>
       </div>
 
-      <AccountTimeline notes={timelineNotes} />
+      {timelineNotes.length === 0 ? (
+        // NOTE: paramsで指定されたアカウントが空である場合は404が表示されるので，ここではnon-null assertionを使う
+        <EmptyAccountTimeline
+          accountName={params.id!}
+          isThisAccountSelf={isThisAccountSelf}
+        />
+      ) : (
+        <AccountTimeline notes={timelineNotes} />
+      )}
     </>
   );
 }
@@ -126,6 +141,31 @@ const AccountTimeline = ({ notes }: AccountTimelineProps) => {
           <LoadMoreNoteButton type="older" noteID={notes.at(-1)!.id} />
         )}
       </div>
+    </div>
+  );
+};
+
+const EmptyAccountTimeline = ({
+  accountName,
+  isThisAccountSelf,
+}: {
+  accountName: string;
+  isThisAccountSelf: boolean;
+}) => {
+  return (
+    <div className={styles.emptyState}>
+      <span>💭</span>
+      {isThisAccountSelf ? (
+        <>
+          <h3>No notes yet</h3>
+          <p>Your notes will appear here when you post them.</p>
+        </>
+      ) : (
+        <>
+          <h3>No notes yet</h3>
+          <p>{accountName} hasn&#39;t made any notes yet.</p>
+        </>
+      )}
     </div>
   );
 };

--- a/app/styles/account.module.css
+++ b/app/styles/account.module.css
@@ -7,3 +7,14 @@
 .accountData {
   height: 15rem;
 }
+
+.emptyState {
+  width: 100%;
+  height: 100%;
+
+  text-align: center;
+
+  span {
+    font-size: 3rem;
+  }
+}


### PR DESCRIPTION
close #302 

## やったこと
- アカウントタイムラインページ(`/accounts/{:id}`)で表示できるノートが0件の場合はempty state
(後述)を表示するようにしました

他人のアカウントの場合
<img width="300" alt="他人のアカウントの場合のスクリーンショット" src="https://github.com/user-attachments/assets/fefc6c4e-18e4-4bbe-81de-513798f473a9" />

自分の場合のスクリーンショット
<img width="300" alt="自分の場合のスクリーンショット" src="https://github.com/user-attachments/assets/45588171-f751-4f62-8e56-1101426bb042" />

### 補足情報
自分の場合は"投稿する"ボタンを設置しようと思いましたが，投稿フォームは現在ホームタイムラインにしかないので任意の場所で投稿できるようにしてからにします

