### PR TITLE
chore: APIを叩く処理を共通化した

### DIFF
--- a/app/components/sideBar.tsx
+++ b/app/components/sideBar.tsx
@@ -1,10 +1,6 @@
 import { Link } from "react-router";
 import style from "~/components/sideBar.module.css";
-<<<<<<< HEAD
-import type { LoggedInAccountDatum } from "~/lib/loggedInAccount";
-=======
-import { LoggedInAccountDatum } from "~/lib/api/loggedInAccount";
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
+import type { LoggedInAccountDatum } from "~/lib/api/loggedInAccount";
 
 interface SideBarLink {
   name: string;

--- a/app/components/sideBar.tsx
+++ b/app/components/sideBar.tsx
@@ -1,6 +1,10 @@
 import { Link } from "react-router";
 import style from "~/components/sideBar.module.css";
+<<<<<<< HEAD
 import type { LoggedInAccountDatum } from "~/lib/loggedInAccount";
+=======
+import { LoggedInAccountDatum } from "~/lib/api/loggedInAccount";
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
 
 interface SideBarLink {
   name: string;

--- a/app/lib/account.ts
+++ b/app/lib/account.ts
@@ -1,4 +1,4 @@
-import type { TimelineResponse } from "~/lib/timeline";
+import type { TimelineResponse } from "~/lib/api/timeline";
 
 export interface AccountResponse {
   id: string;
@@ -14,10 +14,11 @@ export interface AccountResponse {
 
 export const account = async (
   identifier: string,
-  token: string | undefined
+  token: string | undefined,
+  basePath: string
 ): Promise<AccountResponse | { error: string }> => {
   try {
-    const res = await fetch(`http://localhost:3000/v0/accounts/${identifier}`, {
+    const res = await fetch(`${basePath}/v0/accounts/${identifier}`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -34,10 +35,11 @@ export const account = async (
 export const accountTimeline = async (
   id: string,
   token: string | undefined,
+  basePath: string,
   beforeID?: string
 ): Promise<TimelineResponse[] | { error: string }> => {
   try {
-    const url = new URL(`http://localhost:3000/v0/timeline/accounts/${id}`);
+    const url = new URL(`${basePath}/v0/timeline/accounts/${id}`);
     if (beforeID) {
       url.searchParams.append("before_id", beforeID);
     }

--- a/app/lib/account.ts
+++ b/app/lib/account.ts
@@ -18,7 +18,7 @@ export const account = async (
   basePath: string
 ): Promise<AccountResponse | { error: string }> => {
   try {
-    const res = await fetch(`${basePath}/v0/accounts/${identifier}`, {
+    const res = await fetch(new URL(`/v0/accounts/${identifier}`, basePath), {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -39,7 +39,7 @@ export const accountTimeline = async (
   beforeID?: string
 ): Promise<TimelineResponse[] | { error: string }> => {
   try {
-    const url = new URL(`${basePath}/v0/timeline/accounts/${id}`);
+    const url = new URL(`/v0/timeline/accounts/${id}`, basePath);
     if (beforeID) {
       url.searchParams.append("before_id", beforeID);
     }

--- a/app/lib/api/account.ts
+++ b/app/lib/api/account.ts
@@ -1,0 +1,111 @@
+import {
+  GetV0AccountsIdentifierResponse,
+  GetV0TimelineAccountsIdResponse,
+} from "@pulsate-dev/exp-api-types";
+import { TimelineResponse } from "~/lib/api/timeline";
+
+export interface AccountResponse {
+  id: string;
+  name: string;
+  nickname: string;
+  bio: string;
+  avatar: string;
+  header: string;
+  followed_count: number;
+  following_count: number;
+  note_count: number;
+}
+
+export const account = async (
+  identifier: string,
+  token: string | undefined,
+  basePath: string
+): Promise<AccountResponse | { error: string }> => {
+  try {
+    const res = await fetch(`${basePath}/v0/accounts/${identifier}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) {
+      switch (res.status) {
+        case 500:
+          return { error: "internal server error" };
+        case 404:
+          return { error: "account not found" };
+        default:
+          return { error: "unknown error" };
+      }
+    }
+
+    const repsonse = (await res.json()) as GetV0AccountsIdentifierResponse;
+
+    return {
+      id: repsonse.id,
+      name: repsonse.name,
+      nickname: repsonse.nickname,
+      bio: repsonse.bio,
+      avatar: repsonse.avatar,
+      header: repsonse.header,
+      followed_count: repsonse.followed_count,
+      following_count: repsonse.following_count,
+      note_count: repsonse.note_count,
+    } satisfies AccountResponse;
+  } catch {
+    return { error: "unknown error" };
+  }
+};
+
+export const accountTimeline = async (
+  id: string,
+  token: string | undefined,
+  basePath: string,
+  beforeID?: string
+): Promise<TimelineResponse[] | { error: string }> => {
+  try {
+    const url = new URL(`${basePath}/v0/timeline/accounts/${id}`);
+    if (beforeID) {
+      url.searchParams.append("before_id", beforeID);
+    }
+
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) {
+      return (await res.json()) as { error: string };
+    }
+
+    const response = (await res.json()) as GetV0TimelineAccountsIdResponse;
+
+    return response.map(
+      (item) =>
+        ({
+          id: item.id,
+          content: item.content,
+          contents_warning_comment: item.contents_warning_comment,
+          visibility: item.visibility as "PUBLIC" | "HOME" | "FOLLOWERS",
+          created_at: new Date(item.created_at),
+          author: {
+            id: item.author.id,
+            name: item.author.name,
+            display_name: item.author.display_name,
+            bio: item.author.bio,
+            avatar: item.author.avatar,
+            header: item.author.header,
+            followed_count: item.author.followed_count,
+            following_count: item.author.following_count,
+          },
+          reactions: item.reactions.map(
+            (reaction): TimelineResponse["reactions"][number] => ({
+              emoji: reaction.emoji,
+              reacted_by: reaction.reacted_by,
+            })
+          ),
+        }) satisfies TimelineResponse
+    );
+  } catch {
+    return { error: "unknown error" };
+  }
+};

--- a/app/lib/api/account.ts
+++ b/app/lib/api/account.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   GetV0AccountsIdentifierResponse,
   GetV0TimelineAccountsIdResponse,
 } from "@pulsate-dev/exp-api-types";
-import { TimelineResponse } from "~/lib/api/timeline";
+import type { TimelineResponse } from "~/lib/api/timeline";
 
 export interface AccountResponse {
   id: string;

--- a/app/lib/api/account.ts
+++ b/app/lib/api/account.ts
@@ -22,7 +22,7 @@ export const account = async (
   basePath: string
 ): Promise<AccountResponse | { error: string }> => {
   try {
-    const res = await fetch(`${basePath}/v0/accounts/${identifier}`, {
+    const res = await fetch(new URL(`/v0/accounts/${identifier}`, basePath), {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -63,7 +63,7 @@ export const accountTimeline = async (
   beforeID?: string
 ): Promise<TimelineResponse[] | { error: string }> => {
   try {
-    const url = new URL(`${basePath}/v0/timeline/accounts/${id}`);
+    const url = new URL(`/v0/timeline/accounts/${id}`, basePath);
     if (beforeID) {
       url.searchParams.append("before_id", beforeID);
     }

--- a/app/lib/api/getToken.ts
+++ b/app/lib/api/getToken.ts
@@ -1,0 +1,15 @@
+import { accountCookie } from "./login";
+
+/**
+ * Returns account Access Token.
+ */
+export async function getToken(
+  request: Request<unknown, CfProperties<unknown>>
+): Promise<{ isLoggedIn: true; token: string } | { isLoggedIn: false }> {
+  const token = await accountCookie.parse(request.headers.get("Cookie"));
+  if (!token) {
+    return { isLoggedIn: false };
+  }
+
+  return { isLoggedIn: true, token };
+}

--- a/app/lib/api/loggedInAccount.ts
+++ b/app/lib/api/loggedInAccount.ts
@@ -1,7 +1,6 @@
 import { parseToken } from "../parseToken";
 import { account } from "./account";
 import { getToken } from "./getToken";
-import { accountCookie } from "./login";
 
 export interface LoggedInAccountDatum {
   id: string;
@@ -22,7 +21,7 @@ export async function loggedInAccount(
   request: Request<unknown, CfProperties<unknown>>,
   basePath: string
 ): Promise<LoggedInAccountResponse> {
-  const isLoggedIn = await getToken(request)
+  const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
     return { isSuccess: false };
   }

--- a/app/lib/api/loggedInAccount.ts
+++ b/app/lib/api/loggedInAccount.ts
@@ -1,6 +1,6 @@
+import { parseToken } from "../parseToken";
 import { account } from "./account";
 import { accountCookie } from "./login";
-import { parseToken } from "../parseToken";
 
 export interface LoggedInAccountDatum {
   id: string;

--- a/app/lib/api/loggedInAccount.ts
+++ b/app/lib/api/loggedInAccount.ts
@@ -1,5 +1,6 @@
 import { parseToken } from "../parseToken";
 import { account } from "./account";
+import { getToken } from "./getToken";
 import { accountCookie } from "./login";
 
 export interface LoggedInAccountDatum {
@@ -21,10 +22,11 @@ export async function loggedInAccount(
   request: Request<unknown, CfProperties<unknown>>,
   basePath: string
 ): Promise<LoggedInAccountResponse> {
-  const token = await accountCookie.parse(request.headers.get("Cookie"));
-  if (!token) {
+  const isLoggedIn = await getToken(request)
+  if (!isLoggedIn.isLoggedIn) {
     return { isSuccess: false };
   }
+  const token = isLoggedIn.token;
 
   const parsedToken = parseToken(token);
   if (parsedToken instanceof Error) {

--- a/app/lib/api/loggedInAccount.ts
+++ b/app/lib/api/loggedInAccount.ts
@@ -1,6 +1,6 @@
 import { account } from "./account";
 import { accountCookie } from "./login";
-import { parseToken } from "./parseToken";
+import { parseToken } from "../parseToken";
 
 export interface LoggedInAccountDatum {
   id: string;
@@ -18,7 +18,8 @@ export type LoggedInAccountResponse =
   | { isSuccess: false };
 
 export async function loggedInAccount(
-  request: Request<unknown, CfProperties<unknown>>
+  request: Request<unknown, CfProperties<unknown>>,
+  basePath: string
 ): Promise<LoggedInAccountResponse> {
   const token = await accountCookie.parse(request.headers.get("Cookie"));
   if (!token) {
@@ -30,7 +31,7 @@ export async function loggedInAccount(
     return { isSuccess: false };
   }
 
-  const accountDatum = await account(parsedToken.id, token);
+  const accountDatum = await account(parsedToken.id, token, basePath);
   if ("error" in accountDatum) {
     return { isSuccess: false };
   }

--- a/app/lib/api/login.ts
+++ b/app/lib/api/login.ts
@@ -1,3 +1,7 @@
+import {
+  PostV0LoginError,
+  PostV0LoginResponse,
+} from "@pulsate-dev/exp-api-types";
 import { createCookie } from "react-router";
 
 export type LoginArgs = {
@@ -8,14 +12,14 @@ export type LoginArgs = {
 export const login = async ({
   name,
   passphrase,
-}: LoginArgs): Promise<
+}: LoginArgs, basePath: string): Promise<
   | { error: string }
   | {
       authorization_token: string;
     }
 > => {
   try {
-    const response = await fetch("http://localhost:3000/v0/login", {
+    const response = await fetch(`${basePath}/v0/login`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -31,8 +35,8 @@ export const login = async ({
     }
 
     const res = (await response.json()) as
-      | { error: string }
-      | { authorization_token: string };
+      | PostV0LoginError
+      | PostV0LoginResponse;
 
     if ("authorization_token" in res) {
       return { authorization_token: res.authorization_token };

--- a/app/lib/api/login.ts
+++ b/app/lib/api/login.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   PostV0LoginError,
   PostV0LoginResponse,
 } from "@pulsate-dev/exp-api-types";

--- a/app/lib/api/login.ts
+++ b/app/lib/api/login.ts
@@ -19,7 +19,7 @@ export const login = async (
     }
 > => {
   try {
-    const response = await fetch(new URL(`/v0/login`, basePath), {
+    const response = await fetch(new URL("/v0/login", basePath), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/lib/api/login.ts
+++ b/app/lib/api/login.ts
@@ -9,10 +9,10 @@ export type LoginArgs = {
   passphrase: string;
 };
 
-export const login = async ({
-  name,
-  passphrase,
-}: LoginArgs, basePath: string): Promise<
+export const login = async (
+  { name, passphrase }: LoginArgs,
+  basePath: string
+): Promise<
   | { error: string }
   | {
       authorization_token: string;

--- a/app/lib/api/login.ts
+++ b/app/lib/api/login.ts
@@ -19,7 +19,7 @@ export const login = async (
     }
 > => {
   try {
-    const response = await fetch(`${basePath}/v0/login`, {
+    const response = await fetch(new URL(`/v0/login`, basePath), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/lib/api/timeline.ts
+++ b/app/lib/api/timeline.ts
@@ -22,10 +22,11 @@ export interface TimelineResponse {
 
 export const fetchHomeTimeline = async (
   token: string,
+  basePath: string,
   beforeID?: string
 ): Promise<{ notes: TimelineResponse[] } | { error: string }> => {
   try {
-    const url = new URL("http://localhost:3000/v0/timeline/home");
+    const url = new URL(`${basePath}/v0/timeline/home`);
     if (beforeID) {
       url.searchParams.append("before_id", beforeID);
     }

--- a/app/lib/api/timeline.ts
+++ b/app/lib/api/timeline.ts
@@ -26,7 +26,7 @@ export const fetchHomeTimeline = async (
   beforeID?: string
 ): Promise<{ notes: TimelineResponse[] } | { error: string }> => {
   try {
-    const url = new URL(`/v0/timeline/home`, basePath);
+    const url = new URL("/v0/timeline/home", basePath);
     if (beforeID) {
       url.searchParams.append("before_id", beforeID);
     }

--- a/app/lib/api/timeline.ts
+++ b/app/lib/api/timeline.ts
@@ -26,7 +26,7 @@ export const fetchHomeTimeline = async (
   beforeID?: string
 ): Promise<{ notes: TimelineResponse[] } | { error: string }> => {
   try {
-    const url = new URL(`${basePath}/v0/timeline/home`);
+    const url = new URL(`/v0/timeline/home`, basePath);
     if (beforeID) {
       url.searchParams.append("before_id", beforeID);
     }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -11,12 +11,12 @@ import styles from "~/root.module.css";
 import {
   loggedInAccount,
   type LoggedInAccountResponse,
-} from "./lib/loggedInAccount";
+} from "~/lib/api/loggedInAccount";
 
 export async function loader({
   request,
 }: LoaderFunctionArgs): Promise<LoggedInAccountResponse> {
-  return loggedInAccount(request);
+  return loggedInAccount(request, "");
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,17 +7,17 @@ import {
   useLoaderData,
 } from "react-router";
 import { SideBar } from "~/components/sideBar";
-import styles from "~/root.module.css";
 import {
   loggedInAccount,
   type LoggedInAccountResponse,
 } from "~/lib/api/loggedInAccount";
+import styles from "~/root.module.css";
 
 export async function loader({
   request,
   context,
 }: LoaderFunctionArgs): Promise<LoggedInAccountResponse> {
-    const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+  const basePath = (context.cloudflare.env as Env).API_BASE_URL;
   return loggedInAccount(request, basePath);
 }
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,8 +15,10 @@ import {
 
 export async function loader({
   request,
+  context,
 }: LoaderFunctionArgs): Promise<LoggedInAccountResponse> {
-  return loggedInAccount(request, "");
+    const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+  return loggedInAccount(request, basePath);
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,13 +1,7 @@
-<<<<<<< HEAD
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 import { account } from "~/lib/account";
-import { accountCookie } from "~/lib/login";
-=======
-import { Link, LoaderFunctionArgs, useLoaderData } from "react-router";
-import { account } from "~/lib/api/account";
 import { accountCookie } from "~/lib/api/login";
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
 import { parseToken } from "~/lib/parseToken";
 
 export const loader = async ({

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,13 @@
+<<<<<<< HEAD
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 import { account } from "~/lib/account";
 import { accountCookie } from "~/lib/login";
+=======
+import { Link, LoaderFunctionArgs, useLoaderData } from "react-router";
+import { account } from "~/lib/api/account";
+import { accountCookie } from "~/lib/api/login";
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
 import { parseToken } from "~/lib/parseToken";
 
 export const loader = async ({

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,23 +1,26 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 import { account } from "~/lib/account";
-import { accountCookie } from "~/lib/api/login";
+import { getToken } from "~/lib/api/getToken";
 import { parseToken } from "~/lib/parseToken";
 
 export const loader = async ({
   request,
+  context,
 }: LoaderFunctionArgs): Promise<{ isLoggedIn: boolean }> => {
-  const token = await accountCookie.parse(request.headers.get("Cookie"));
-  if (!token) {
+  const isLoggedIn = await getToken(request);
+  if (!isLoggedIn.isLoggedIn) {
     return { isLoggedIn: false };
   }
+  const token = isLoggedIn.token;
 
   const parsedToken = parseToken(token);
   if (parsedToken instanceof Error) {
     return { isLoggedIn: false };
   }
 
-  const accountDatum = await account(parsedToken.id, token);
+  const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+  const accountDatum = await account(parsedToken.id, token, basePath);
   return { isLoggedIn: !("error" in accountDatum) };
 };
 

--- a/app/routes/accounts.$id.tsx
+++ b/app/routes/accounts.$id.tsx
@@ -43,7 +43,12 @@ export const loader = async ({
     throw new Error("before_id and after_id cannot be used together");
   }
 
-  const timelineRes = await accountTimeline(accountRes.id, token, basePath, beforeID);
+  const timelineRes = await accountTimeline(
+    accountRes.id,
+    token,
+    basePath,
+    beforeID
+  );
   if ("error" in timelineRes) {
     return { error: timelineRes.error };
   }

--- a/app/routes/accounts.$id.tsx
+++ b/app/routes/accounts.$id.tsx
@@ -5,9 +5,9 @@ import type { NoteProps } from "~/components/note";
 import { Note } from "~/components/note";
 import type { AccountResponse } from "~/lib/account";
 import { account, accountTimeline } from "~/lib/account";
-import { loggedInAccount } from "~/lib/loggedInAccount";
-import { accountCookie } from "~/lib/login";
-import type { TimelineResponse } from "~/lib/timeline";
+import { loggedInAccount } from "~/lib/api/loggedInAccount";
+import { accountCookie } from "~/lib/api/login";
+import type { TimelineResponse } from "~/lib/api/timeline";
 import styles from "~/styles/account.module.css";
 
 export const loader = async ({

--- a/app/routes/accounts.$id.tsx
+++ b/app/routes/accounts.$id.tsx
@@ -5,8 +5,8 @@ import type { NoteProps } from "~/components/note";
 import { Note } from "~/components/note";
 import type { AccountResponse } from "~/lib/account";
 import { account, accountTimeline } from "~/lib/account";
+import { getToken } from "~/lib/api/getToken";
 import { loggedInAccount } from "~/lib/api/loggedInAccount";
-import { accountCookie } from "~/lib/api/login";
 import type { TimelineResponse } from "~/lib/api/timeline";
 import styles from "~/styles/account.module.css";
 
@@ -25,10 +25,12 @@ export const loader = async ({
 > => {
   const basePath = (context.cloudflare.env as Env).API_BASE_URL;
 
-  const token = await accountCookie.parse(request.headers.get("Cookie"));
-  if (!token) {
+  const isLoggedIn = await getToken(request);
+  if (!isLoggedIn.isLoggedIn) {
     return { error: "not logged in" };
   }
+  const token = isLoggedIn.token;
+
   if (!params.id) return { error: "invalid id" };
 
   const accountRes = await account(params.id, token, basePath);

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,7 +1,7 @@
 import type { ActionFunctionArgs } from "react-router";
 import { accountCookie } from "~/lib/api/login";
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const token = await accountCookie.parse(request.headers.get("Cookie"));
   if (!token) {
     return { error: "unauthorized" };
@@ -9,7 +9,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   try {
     const formData = await request.formData();
-    const res = await fetch("http://localhost:3000/v0/notes", {
+      const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+    const res = await fetch(`${basePath}/v0/notes`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { accountCookie } from "~/lib/login";
+import { accountCookie } from "~/lib/api/login";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const token = await accountCookie.parse(request.headers.get("Cookie"));

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -11,7 +11,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   try {
     const formData = await request.formData();
     const basePath = (context.cloudflare.env as Env).API_BASE_URL;
-    const res = await fetch(new URL(`/v0/notes`, basePath), {
+    const res = await fetch(new URL("/v0/notes", basePath), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -10,7 +10,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   try {
     const formData = await request.formData();
     const basePath = (context.cloudflare.env as Env).API_BASE_URL;
-    const res = await fetch(`${basePath}/v0/notes`, {
+    const res = await fetch(new URL(`/v0/notes`, basePath), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,11 +1,12 @@
 import type { ActionFunctionArgs } from "react-router";
-import { accountCookie } from "~/lib/api/login";
+import { getToken } from "~/lib/api/getToken";
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
-  const token = await accountCookie.parse(request.headers.get("Cookie"));
-  if (!token) {
+  const isLoggedIn = await getToken(request);
+  if (!isLoggedIn.isLoggedIn) {
     return { error: "unauthorized" };
   }
+  const token = isLoggedIn.token;
 
   try {
     const formData = await request.formData();

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -9,7 +9,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   try {
     const formData = await request.formData();
-      const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+    const basePath = (context.cloudflare.env as Env).API_BASE_URL;
     const res = await fetch(`${basePath}/v0/notes`, {
       method: "POST",
       headers: {

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -39,7 +39,7 @@ const reaction = async (
   basePath: string
 ): Promise<{ status: string } | { error: string }> => {
   try {
-    const res = await fetch(`${basePath}/v0/notes/${noteID}/reaction`, {
+    const res = await fetch(new URL(`/v0/notes/${noteID}/reaction`, basePath), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -67,7 +67,7 @@ const undoReaction = async (
   basePath: string
 ): Promise<{ status: string } | { error: string }> => {
   try {
-    const res = await fetch(`${basePath}/v0/notes/${noteID}/reaction`, {
+    const res = await fetch(new URL(`/v0/notes/${noteID}/reaction`, basePath), {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { accountCookie } from "~/lib/login";
+import { accountCookie } from "~/lib/api/login";
 
 export const action = async ({
   request,

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -22,7 +22,11 @@ export const action = async ({
         basePath
       );
     case "DELETE":
-      return await undoReaction(formData.get("noteID") as string, token, basePath);
+      return await undoReaction(
+        formData.get("noteID") as string,
+        token,
+        basePath
+      );
     default:
       return { error: "method not allowed" };
   }
@@ -63,16 +67,13 @@ const undoReaction = async (
   basePath: string
 ): Promise<{ status: string } | { error: string }> => {
   try {
-    const res = await fetch(
-      `${basePath}/v0/notes/${noteID}/reaction`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
+    const res = await fetch(`${basePath}/v0/notes/${noteID}/reaction`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
 
     if (!res.ok) {
       throw new Error("Failed to undo reaction");

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -1,14 +1,15 @@
 import type { ActionFunctionArgs } from "react-router";
-import { accountCookie } from "~/lib/api/login";
+import { getToken } from "~/lib/api/getToken";
 
 export const action = async ({
   request,
   context,
 }: ActionFunctionArgs): Promise<{ error: string } | { status: string }> => {
-  const token = await accountCookie.parse(request.headers.get("Cookie"));
-  if (!token) {
+  const isLoggedIn = await getToken(request);
+  if (!isLoggedIn.isLoggedIn) {
     return { error: "unauthorized" };
   }
+  const token = isLoggedIn.token;
 
   const formData = await request.formData();
   const basePath = (context.cloudflare.env as Env).API_BASE_URL;

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -2,7 +2,7 @@ import type { ActionFunctionArgs, MetaFunction } from "react-router";
 import { Form, Link, redirect } from "react-router";
 
 import styles from "~/components/login.module.css";
-import { accountCookie, login } from "~/lib/login";
+import { accountCookie, login } from "~/lib/api/login";
 
 export const meta: MetaFunction = () => {
   return [
@@ -15,12 +15,12 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   const formData = await request.formData();
   const name = formData.get("name") as string;
   const passphrase = formData.get("passphrase") as string;
 
-  const res = await login({ name, passphrase });
+  const res = await login({ name, passphrase }, context);
   if ("error" in res) {
     return res.error;
   }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -20,7 +20,8 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   const name = formData.get("name") as string;
   const passphrase = formData.get("passphrase") as string;
 
-  const res = await login({ name, passphrase }, context);
+  const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+  const res = await login({ name, passphrase }, basePath);
   if ("error" in res) {
     return res.error;
   }

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -1,5 +1,5 @@
 import { Form, redirect } from "react-router";
-import { accountCookie } from "~/lib/login";
+import { accountCookie } from "~/lib/api/login";
 
 export const action = async () => {
   const resetCookie = await accountCookie.serialize("", {

--- a/app/routes/signup.verify.tsx
+++ b/app/routes/signup.verify.tsx
@@ -3,6 +3,7 @@ import { Link, useLoaderData } from "react-router";
 
 export const loader = async ({
   request,
+  context,
 }: LoaderFunctionArgs): Promise<{ error: string } | { status: "ok" }> => {
   const query = new URL(request.url).searchParams;
 
@@ -14,8 +15,9 @@ export const loader = async ({
     };
   }
   try {
+    const basePath = (context.cloudflare.env as Env).API_BASE_URL;
     const res = await fetch(
-      `http://localhost:3000/v0/accounts/${accountName}/verify_email`,
+      `${basePath}/v0/accounts/${accountName}/verify_email`,
       {
         method: "POST",
         headers: {

--- a/app/routes/signup.verify.tsx
+++ b/app/routes/signup.verify.tsx
@@ -17,7 +17,7 @@ export const loader = async ({
   try {
     const basePath = (context.cloudflare.env as Env).API_BASE_URL;
     const res = await fetch(
-      `${basePath}/v0/accounts/${accountName}/verify_email`,
+      new URL(`/v0/accounts/${accountName}/verify_email`, basePath),
       {
         method: "POST",
         headers: {

--- a/app/routes/timeline.tsx
+++ b/app/routes/timeline.tsx
@@ -4,10 +4,10 @@ import { EmptyState } from "~/components/emptyState";
 import { LoadMoreNoteButton } from "~/components/loadMoreNote";
 import { Note } from "~/components/note";
 import { PostForm } from "~/components/postForm";
-import { loggedInAccount } from "~/lib/loggedInAccount";
-import { accountCookie } from "~/lib/login";
-import type { TimelineResponse } from "~/lib/timeline";
-import { fetchHomeTimeline } from "~/lib/timeline";
+import { loggedInAccount } from "~/lib/api/loggedInAccount";
+import { accountCookie } from "~/lib/api/login";
+import type { TimelineResponse } from "~/lib/api/timeline";
+import { fetchHomeTimeline } from "~/lib/api/timeline";
 import styles from "~/styles/timeline.module.css";
 
 export const meta: MetaFunction = () => {

--- a/app/routes/timeline.tsx
+++ b/app/routes/timeline.tsx
@@ -16,7 +16,7 @@ export const meta: MetaFunction = () => {
 
 export const loader = async ({
   request,
-  context
+  context,
 }: LoaderFunctionArgs): Promise<
   | { error: string }
   | {
@@ -34,7 +34,7 @@ export const loader = async ({
 
   const query = new URL(request.url).searchParams;
   const beforeID = query.get("before_id") ?? undefined;
-  const res = await fetchHomeTimeline(cookie, basePath,beforeID);
+  const res = await fetchHomeTimeline(cookie, basePath, beforeID);
   if ("error" in res) {
     return res;
   }

--- a/app/routes/timeline.tsx
+++ b/app/routes/timeline.tsx
@@ -16,6 +16,7 @@ export const meta: MetaFunction = () => {
 
 export const loader = async ({
   request,
+  context
 }: LoaderFunctionArgs): Promise<
   | { error: string }
   | {
@@ -24,6 +25,8 @@ export const loader = async ({
     }
   | Response
 > => {
+  const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+
   const cookie = await accountCookie.parse(request.headers.get("Cookie"));
   if (!cookie) {
     return redirect("/login");
@@ -31,12 +34,12 @@ export const loader = async ({
 
   const query = new URL(request.url).searchParams;
   const beforeID = query.get("before_id") ?? undefined;
-  const res = await fetchHomeTimeline(cookie, beforeID);
+  const res = await fetchHomeTimeline(cookie, basePath,beforeID);
   if ("error" in res) {
     return res;
   }
 
-  const loggedInAccountDatum = await loggedInAccount(request);
+  const loggedInAccountDatum = await loggedInAccount(request, basePath);
   if (!loggedInAccountDatum.isSuccess) {
     return { error: "not logged in" };
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.5.0",
     "@marsidev/react-turnstile": "^1.1.0",
+    "@pulsate-dev/exp-api-types": "^0.0.1",
     "@react-router/cloudflare": "^7.6.1",
     "@react-router/fs-routes": "^7.6.1",
     "isbot": "^5.1.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,7 @@ importers:
     dependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.5.0
-<<<<<<< HEAD
         version: 1.5.0(rollup@4.42.0)(vite@6.3.5(yaml@2.8.0))(workerd@1.20250525.0)(wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0))
-=======
-        version: 1.5.0(rollup@4.41.1)(vite@6.3.5(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(workerd@1.20250525.0)(wrangler@4.18.0(@cloudflare/workers-types@4.20250531.0))
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
       '@marsidev/react-turnstile':
         specifier: ^1.1.0
         version: 1.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -845,16 +841,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-<<<<<<< HEAD
-  '@react-router/cloudflare@7.6.2':
-    resolution: {integrity: sha512-nA3PLrm9UG4G+jOzr34DeByA04Mxwkgmq4cV7YnHXqeKK90odYOMnd+XJp+NbTVcmvBXq+CatytL5JP+1goGYw==}
-=======
   '@pulsate-dev/exp-api-types@0.0.1':
     resolution: {integrity: sha512-i4vlPyfKOXvKqrZnmVvPPrl3Bos2FlIEPaPInFCOPu7qQsc9fS9pCy3WPJiKr/s/KpIDfqT92Rchpe+g/gfRXQ==}
 
-  '@react-router/cloudflare@7.6.1':
-    resolution: {integrity: sha512-vhRSojaIgOJEBVSyP3bRTwz2CXoaGkBHDj2DSyabCJg+oO6atGZqocVrhcchCRAo2LVe6xaQw2fFTrfPI+XU2g==}
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
+  '@react-router/cloudflare@7.6.2':
+    resolution: {integrity: sha512-nA3PLrm9UG4G+jOzr34DeByA04Mxwkgmq4cV7YnHXqeKK90odYOMnd+XJp+NbTVcmvBXq+CatytL5JP+1goGYw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@cloudflare/workers-types': ^4.0.0
@@ -921,13 +912,8 @@ packages:
       rollup:
         optional: true
 
-<<<<<<< HEAD
   '@rollup/rollup-android-arm-eabi@4.42.0':
     resolution: {integrity: sha512-gldmAyS9hpj+H6LpRNlcjQWbuKUtb94lodB9uCz71Jm+7BxK1VIOo7y62tZZwxhA7j1ylv/yQz080L5WkS+LoQ==}
-=======
-  '@rollup/rollup-android-arm-eabi@4.40.0':
-    resolution: {integrity: sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==}
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
     cpu: [arm]
     os: [android]
 
@@ -2004,11 +1990,6 @@ packages:
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
-    hasBin: true
-
-  miniflare@4.20250525.1:
-    resolution: {integrity: sha512-4PJlT5WA+hfclFU5Q7xnpG1G1VGYTXaf/3iu6iKQ8IsbSi9QvPTA2bSZ5goCFxmJXDjV4cxttVxB0Wl1CLuQ0w==}
-    engines: {node: '>=18.0.0'}
     hasBin: true
 
   miniflare@4.20250525.1:
@@ -3099,31 +3080,18 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250525.0
 
-<<<<<<< HEAD
   '@cloudflare/vite-plugin@1.5.0(rollup@4.42.0)(vite@6.3.5(yaml@2.8.0))(workerd@1.20250525.0)(wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250525.0)
       '@mjackson/node-fetch-server': 0.6.1
       '@rollup/plugin-replace': 6.0.2(rollup@4.42.0)
-=======
-  '@cloudflare/vite-plugin@1.5.0(rollup@4.41.1)(vite@6.3.5(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(workerd@1.20250525.0)(wrangler@4.18.0(@cloudflare/workers-types@4.20250531.0))':
-    dependencies:
-      '@cloudflare/unenv-preset': 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250525.0)
-      '@mjackson/node-fetch-server': 0.6.1
-      '@rollup/plugin-replace': 6.0.2(rollup@4.41.1)
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
       get-port: 7.1.0
       miniflare: 4.20250525.1
       picocolors: 1.1.1
       tinyglobby: 0.2.14
       unenv: 2.0.0-rc.17
-<<<<<<< HEAD
       vite: 6.3.5(yaml@2.8.0)
       wrangler: 4.19.1(@cloudflare/workers-types@4.20250610.0)
-=======
-      vite: 6.3.5(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
-      wrangler: 4.18.0(@cloudflare/workers-types@4.20250531.0)
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -3537,13 +3505,9 @@ snapshots:
     dependencies:
       playwright: 1.52.0
 
-<<<<<<< HEAD
-  '@react-router/cloudflare@7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsup@8.5.0(postcss@8.5.4)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)':
-=======
   '@pulsate-dev/exp-api-types@0.0.1': {}
 
-  '@react-router/cloudflare@7.6.1(@cloudflare/workers-types@4.20250531.0)(react-router@7.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsup@8.5.0(jiti@1.21.7)(postcss@8.5.4)(typescript@5.8.3)(yaml@2.7.1))(typescript@5.8.3)':
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
+  '@react-router/cloudflare@7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsup@8.5.0(postcss@8.5.4)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)':
     dependencies:
       '@cloudflare/workers-types': 4.20250610.0
       react-router: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3618,7 +3582,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-<<<<<<< HEAD
   '@rollup/plugin-replace@6.0.2(rollup@4.42.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.42.0)
@@ -3635,24 +3598,6 @@ snapshots:
       rollup: 4.42.0
 
   '@rollup/rollup-android-arm-eabi@4.42.0':
-=======
-  '@rollup/plugin-replace@6.0.2(rollup@4.41.1)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
-      magic-string: 0.30.17
-    optionalDependencies:
-      rollup: 4.41.1
-
-  '@rollup/pluginutils@5.1.4(rollup@4.41.1)':
-    dependencies:
-      '@types/estree': 1.0.7
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
-    optionalDependencies:
-      rollup: 4.41.1
-
-  '@rollup/rollup-android-arm-eabi@4.40.0':
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
     optional: true
 
   '@rollup/rollup-android-arm64@4.42.0':
@@ -4865,24 +4810,6 @@ snapshots:
       picomatch: 2.3.1
 
   mime@3.0.0: {}
-
-  miniflare@4.20250525.1:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      acorn: 8.14.0
-      acorn-walk: 8.3.2
-      exit-hook: 2.2.1
-      glob-to-regexp: 0.4.1
-      sharp: 0.33.5
-      stoppable: 1.1.0
-      undici: 5.29.0
-      workerd: 1.20250525.0
-      ws: 8.18.0
-      youch: 3.3.4
-      zod: 3.22.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   miniflare@4.20250525.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,17 @@ importers:
     dependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.5.0
+<<<<<<< HEAD
         version: 1.5.0(rollup@4.42.0)(vite@6.3.5(yaml@2.8.0))(workerd@1.20250525.0)(wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0))
+=======
+        version: 1.5.0(rollup@4.41.1)(vite@6.3.5(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(workerd@1.20250525.0)(wrangler@4.18.0(@cloudflare/workers-types@4.20250531.0))
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
       '@marsidev/react-turnstile':
         specifier: ^1.1.0
         version: 1.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@pulsate-dev/exp-api-types':
+        specifier: ^0.0.1
+        version: 0.0.1
       '@react-router/cloudflare':
         specifier: ^7.6.1
         version: 7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsup@8.5.0(postcss@8.5.4)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)
@@ -838,8 +845,16 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+<<<<<<< HEAD
   '@react-router/cloudflare@7.6.2':
     resolution: {integrity: sha512-nA3PLrm9UG4G+jOzr34DeByA04Mxwkgmq4cV7YnHXqeKK90odYOMnd+XJp+NbTVcmvBXq+CatytL5JP+1goGYw==}
+=======
+  '@pulsate-dev/exp-api-types@0.0.1':
+    resolution: {integrity: sha512-i4vlPyfKOXvKqrZnmVvPPrl3Bos2FlIEPaPInFCOPu7qQsc9fS9pCy3WPJiKr/s/KpIDfqT92Rchpe+g/gfRXQ==}
+
+  '@react-router/cloudflare@7.6.1':
+    resolution: {integrity: sha512-vhRSojaIgOJEBVSyP3bRTwz2CXoaGkBHDj2DSyabCJg+oO6atGZqocVrhcchCRAo2LVe6xaQw2fFTrfPI+XU2g==}
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@cloudflare/workers-types': ^4.0.0
@@ -906,8 +921,13 @@ packages:
       rollup:
         optional: true
 
+<<<<<<< HEAD
   '@rollup/rollup-android-arm-eabi@4.42.0':
     resolution: {integrity: sha512-gldmAyS9hpj+H6LpRNlcjQWbuKUtb94lodB9uCz71Jm+7BxK1VIOo7y62tZZwxhA7j1ylv/yQz080L5WkS+LoQ==}
+=======
+  '@rollup/rollup-android-arm-eabi@4.40.0':
+    resolution: {integrity: sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==}
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
     cpu: [arm]
     os: [android]
 
@@ -1984,6 +2004,11 @@ packages:
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  miniflare@4.20250525.1:
+    resolution: {integrity: sha512-4PJlT5WA+hfclFU5Q7xnpG1G1VGYTXaf/3iu6iKQ8IsbSi9QvPTA2bSZ5goCFxmJXDjV4cxttVxB0Wl1CLuQ0w==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   miniflare@4.20250525.1:
@@ -3074,18 +3099,31 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250525.0
 
+<<<<<<< HEAD
   '@cloudflare/vite-plugin@1.5.0(rollup@4.42.0)(vite@6.3.5(yaml@2.8.0))(workerd@1.20250525.0)(wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250525.0)
       '@mjackson/node-fetch-server': 0.6.1
       '@rollup/plugin-replace': 6.0.2(rollup@4.42.0)
+=======
+  '@cloudflare/vite-plugin@1.5.0(rollup@4.41.1)(vite@6.3.5(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))(workerd@1.20250525.0)(wrangler@4.18.0(@cloudflare/workers-types@4.20250531.0))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250525.0)
+      '@mjackson/node-fetch-server': 0.6.1
+      '@rollup/plugin-replace': 6.0.2(rollup@4.41.1)
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
       get-port: 7.1.0
       miniflare: 4.20250525.1
       picocolors: 1.1.1
       tinyglobby: 0.2.14
       unenv: 2.0.0-rc.17
+<<<<<<< HEAD
       vite: 6.3.5(yaml@2.8.0)
       wrangler: 4.19.1(@cloudflare/workers-types@4.20250610.0)
+=======
+      vite: 6.3.5(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
+      wrangler: 4.18.0(@cloudflare/workers-types@4.20250531.0)
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -3499,7 +3537,13 @@ snapshots:
     dependencies:
       playwright: 1.52.0
 
+<<<<<<< HEAD
   '@react-router/cloudflare@7.6.2(@cloudflare/workers-types@4.20250610.0)(react-router@7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsup@8.5.0(postcss@8.5.4)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)':
+=======
+  '@pulsate-dev/exp-api-types@0.0.1': {}
+
+  '@react-router/cloudflare@7.6.1(@cloudflare/workers-types@4.20250531.0)(react-router@7.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsup@8.5.0(jiti@1.21.7)(postcss@8.5.4)(typescript@5.8.3)(yaml@2.7.1))(typescript@5.8.3)':
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
     dependencies:
       '@cloudflare/workers-types': 4.20250610.0
       react-router: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3574,6 +3618,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+<<<<<<< HEAD
   '@rollup/plugin-replace@6.0.2(rollup@4.42.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.42.0)
@@ -3590,6 +3635,24 @@ snapshots:
       rollup: 4.42.0
 
   '@rollup/rollup-android-arm-eabi@4.42.0':
+=======
+  '@rollup/plugin-replace@6.0.2(rollup@4.41.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
+      magic-string: 0.30.17
+    optionalDependencies:
+      rollup: 4.41.1
+
+  '@rollup/pluginutils@5.1.4(rollup@4.41.1)':
+    dependencies:
+      '@types/estree': 1.0.7
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.41.1
+
+  '@rollup/rollup-android-arm-eabi@4.40.0':
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
     optional: true
 
   '@rollup/rollup-android-arm64@4.42.0':
@@ -4802,6 +4865,24 @@ snapshots:
       picomatch: 2.3.1
 
   mime@3.0.0: {}
+
+  miniflare@4.20250525.1:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.2
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      sharp: 0.33.5
+      stoppable: 1.1.0
+      undici: 5.29.0
+      workerd: 1.20250525.0
+      ws: 8.18.0
+      youch: 3.3.4
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   miniflare@4.20250525.1:
     dependencies:

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,11 +3,6 @@ import type { Config } from "@react-router/dev/config";
 export default {
   ssr: true,
   future: {
-<<<<<<< HEAD
     unstable_viteEnvironmentApi: true,
   },
-=======
-    unstable_viteEnvironmentApi: true
-  }
->>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
 } satisfies Config;

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,6 +3,11 @@ import type { Config } from "@react-router/dev/config";
 export default {
   ssr: true,
   future: {
+<<<<<<< HEAD
     unstable_viteEnvironmentApi: true,
   },
+=======
+    unstable_viteEnvironmentApi: true
+  }
+>>>>>>> 317cc0a (wip: app/libにAPI関連のコードを移動)
 } satisfies Config;


### PR DESCRIPTION
close #311 

## 概要
APIを叩く処理を`/lib/api`に集約しました.
cloudflare workers環境下ではloader.contextで環境変数が渡されるので，それに対応させています
## additional information
関数によってbasePathを受け取る位置が違うの統一したほうが良い気がしています
