### PR TITLE
feat: フォロー/フォロー解除ボタンを設置

### DIFF
--- a/app/components/followButton.tsx
+++ b/app/components/followButton.tsx
@@ -19,7 +19,8 @@ export function FollowButton({
     if (fetcher.state === "loading") {
       if ("error" in fetcher.data) {
         if (fetcher.formMethod === "POST") setIsFollowing(false);
-        if (fetcher.formMethod === "DELETE") setIsFollowing(true);
+        if (fetcher.formMethod === "DELETE")
+          setIsFollowing(relationship.isFollowing);
       }
     }
   }, [fetcher.state]);

--- a/app/components/followButton.tsx
+++ b/app/components/followButton.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { useFetcher } from "react-router";
+import type { AccountRelationshipResponse } from "~/lib/api/relationship";
+import type { action } from "~/routes/api.follow";
+
+export function FollowButton({
+  accountName,
+  relationship,
+}: {
+  accountName: string;
+  relationship: AccountRelationshipResponse;
+}) {
+  const fetcher = useFetcher<typeof action>();
+  const [isFollowing, setIsFollowing] = useState(relationship.isFollowing);
+
+  useEffect(() => {
+    if (!fetcher.data) return;
+
+    if (fetcher.state === "loading") {
+      if ("error" in fetcher.data) {
+        if (fetcher.formMethod === "POST") setIsFollowing(false);
+        if (fetcher.formMethod === "DELETE") setIsFollowing(true);
+      }
+    }
+  }, [fetcher.state]);
+
+  const handleFollow = async () => {
+    setIsFollowing(true);
+    await fetcher.submit(
+      { accountName: accountName },
+      { method: "post", action: "/api/follow" }
+    );
+  };
+  const handleUnfollow = async () => {
+    setIsFollowing(false);
+    await fetcher.submit(
+      { accountName: accountName },
+      { method: "delete", action: "/api/follow" }
+    );
+  };
+
+  /**
+   * フォローしている(isFollowing): フォロー解除
+   * フォローしていない(!isFollowing): フォロー
+   * フォローリクエスト中(isFollowRequesting): リクエスト中
+   * フォローしていないが，相手からフォローされている(isFollowed && !isFollowing): フォローバック
+   */
+  const buttonText = (() => {
+    if (relationship.isFollowRequesting) {
+      return "Follow requesting";
+    } else if (!isFollowing && relationship.isFollowed) {
+      return "Follow back";
+    } else if (!isFollowing) {
+      return "Follow";
+    } else {
+      return "Unfollow";
+    }
+  })();
+
+  return (
+    <button
+      onClick={async () => {
+        if (isFollowing) {
+          await handleUnfollow();
+        } else {
+          await handleFollow();
+        }
+      }}
+    >
+      {buttonText}
+    </button>
+  );
+}

--- a/app/components/followButton.tsx
+++ b/app/components/followButton.tsx
@@ -23,7 +23,7 @@ export function FollowButton({
           setIsFollowing(relationship.isFollowing);
       }
     }
-  }, [fetcher.state]);
+  }, [fetcher.state, fetcher.data, fetcher.formMethod]);
 
   const handleFollow = async () => {
     setIsFollowing(true);

--- a/app/components/followButton.tsx
+++ b/app/components/followButton.tsx
@@ -26,18 +26,18 @@ export function FollowButton({
   }, [fetcher.state, fetcher.data, fetcher.formMethod]);
 
   const handleFollow = async () => {
-    setIsFollowing(true);
     await fetcher.submit(
       { accountName: accountName },
       { method: "post", action: "/api/follow" }
     );
+    setIsFollowing(true);
   };
   const handleUnfollow = async () => {
-    setIsFollowing(false);
     await fetcher.submit(
       { accountName: accountName },
       { method: "delete", action: "/api/follow" }
     );
+    setIsFollowing(false);
   };
 
   /**
@@ -60,11 +60,11 @@ export function FollowButton({
 
   return (
     <button
-      onClick={async () => {
+      onClick={() => {
         if (isFollowing) {
-          await handleUnfollow();
+          handleUnfollow();
         } else {
-          await handleFollow();
+          handleFollow();
         }
       }}
     >

--- a/app/components/followButton.tsx
+++ b/app/components/followButton.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import type { AccountRelationshipResponse } from "~/lib/api/relationship";
 import type { action } from "~/routes/api.follow";
@@ -11,34 +10,6 @@ export function FollowButton({
   relationship: AccountRelationshipResponse;
 }) {
   const fetcher = useFetcher<typeof action>();
-  const [isFollowing, setIsFollowing] = useState(relationship.isFollowing);
-
-  useEffect(() => {
-    if (!fetcher.data) return;
-
-    if (fetcher.state === "loading") {
-      if ("error" in fetcher.data) {
-        if (fetcher.formMethod === "POST") setIsFollowing(false);
-        if (fetcher.formMethod === "DELETE")
-          setIsFollowing(relationship.isFollowing);
-      }
-    }
-  }, [fetcher.state, fetcher.data, fetcher.formMethod]);
-
-  const handleFollow = async () => {
-    await fetcher.submit(
-      { accountName: accountName },
-      { method: "post", action: "/api/follow" }
-    );
-    setIsFollowing(true);
-  };
-  const handleUnfollow = async () => {
-    await fetcher.submit(
-      { accountName: accountName },
-      { method: "delete", action: "/api/follow" }
-    );
-    setIsFollowing(false);
-  };
 
   /**
    * フォローしている(isFollowing): フォロー解除
@@ -49,9 +20,9 @@ export function FollowButton({
   const buttonText = (() => {
     if (relationship.isFollowRequesting) {
       return "Follow requesting";
-    } else if (!isFollowing && relationship.isFollowed) {
+    } else if (!relationship.isFollowing && relationship.isFollowed) {
       return "Follow back";
-    } else if (!isFollowing) {
+    } else if (!relationship.isFollowing) {
       return "Follow";
     } else {
       return "Unfollow";
@@ -61,12 +32,19 @@ export function FollowButton({
   return (
     <button
       onClick={() => {
-        if (isFollowing) {
-          handleUnfollow();
+        if (relationship.isFollowing) {
+          fetcher.submit(
+            { accountName: accountName },
+            { method: "post", action: "/api/follow" }
+          );
         } else {
-          handleFollow();
+          fetcher.submit(
+            { accountName: accountName },
+            { method: "delete", action: "/api/follow" }
+          );
         }
       }}
+      disabled={fetcher.state !== "idle" || relationship.isFollowRequesting}
     >
       {buttonText}
     </button>

--- a/app/lib/api/follow.ts
+++ b/app/lib/api/follow.ts
@@ -39,7 +39,7 @@ export async function unfollowAccount(
         },
       }
     );
-    if (followRes.status != 204) {
+    if (followRes.status !== 204) {
       return { isSuccess: false };
     }
   } catch (e) {

--- a/app/lib/api/follow.ts
+++ b/app/lib/api/follow.ts
@@ -1,0 +1,51 @@
+export async function followAccount(
+  basePath: string,
+  token: string,
+  accountName: string
+): Promise<{ isSuccess: boolean }> {
+  try {
+    const followRes = await fetch(
+      new URL(`/v0/accounts/${accountName}/follow`, basePath),
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    if (!followRes.ok) {
+      return { isSuccess: false };
+    }
+  } catch (e) {
+    console.error("Unexpected Error:", e);
+    return { isSuccess: false };
+  }
+
+  return { isSuccess: true };
+}
+
+export async function unfollowAccount(
+  basePath: string,
+  token: string,
+  accountName: string
+): Promise<{ isSuccess: boolean }> {
+  try {
+    const followRes = await fetch(
+      new URL(`/v0/accounts/${accountName}/follow`, basePath),
+      {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    if (followRes.status != 204) {
+      return { isSuccess: false };
+    }
+  } catch (e) {
+    console.error("Unexpected Error:", e);
+    return { isSuccess: false };
+  }
+
+  return { isSuccess: true };
+}

--- a/app/lib/api/relationship.ts
+++ b/app/lib/api/relationship.ts
@@ -1,0 +1,49 @@
+export interface AccountRelationshipResponse {
+  id: string;
+  isFollowed: boolean;
+  isFollowing: boolean;
+  isFollowRequesting: boolean;
+}
+
+export async function accountRelationship(
+  basePath: string,
+  token: string,
+  accountID: string
+): Promise<
+  | { isSuccess: true; response: AccountRelationshipResponse }
+  | { isSuccess: false }
+> {
+  try {
+    const relationshipRes = await fetch(
+      new URL(`/v0/accounts/${accountID}/relationships`, basePath),
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    if (!relationshipRes.ok) {
+      return { isSuccess: false };
+    }
+
+    // ToDo: exp-api-typesの型を使う
+    const relationship = (await relationshipRes.json()) as {
+      id: string;
+      is_followed: boolean;
+      is_following: boolean;
+      is_follow_requesting: boolean;
+    };
+
+    return {
+      isSuccess: true,
+      response: {
+        id: relationship.id,
+        isFollowed: relationship.is_followed,
+        isFollowing: relationship.is_following,
+        isFollowRequesting: relationship.is_follow_requesting,
+      },
+    };
+  } catch {
+    return { isSuccess: false };
+  }
+}

--- a/app/routes/accounts.$id._index.tsx
+++ b/app/routes/accounts.$id._index.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
-import { useLoaderData, useParams } from "react-router";
+import { useLoaderData } from "react-router";
 import { EmptyState } from "~/components/emptyState";
 import { FollowButton } from "~/components/followButton";
 import { LoadMoreNoteButton } from "~/components/loadMoreNote";
@@ -122,7 +122,7 @@ export default function Account() {
       loggedInAccountID: data.loggedInAccountID ?? "",
     })
   );
-  const params = useParams();
+
   const isThisAccountSelf = data.account.id === data.loggedInAccountID;
   return (
     <>

--- a/app/routes/accounts.$id._index.tsx
+++ b/app/routes/accounts.$id._index.tsx
@@ -123,8 +123,7 @@ export default function Account() {
     })
   );
   const params = useParams();
-  const isThisAccountSelf = !!params.id && params.id === loggedInAccount?.name;
-
+  const isThisAccountSelf = data.account.id === data.loggedInAccountID;
   return (
     <>
       <div className={styles.accountData}>

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -28,6 +28,9 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
           formData.get("accountName") as string
         );
       }
+      default: {
+        return { error: "method not allowed"}
+      }
     }
   } catch (e) {
     console.error(e);

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -1,0 +1,36 @@
+import type { ActionFunctionArgs } from "react-router";
+import { followAccount, unfollowAccount } from "~/lib/api/follow";
+import { getToken } from "~/lib/api/getToken";
+
+export const action = async ({ request, context }: ActionFunctionArgs) => {
+  const isLoggedIn = await getToken(request);
+  if (!isLoggedIn.isLoggedIn) {
+    return { error: "unauthorized" };
+  }
+  const token = isLoggedIn.token;
+
+  try {
+    const formData = await request.formData();
+    const basePath = (context.cloudflare.env as Env).API_BASE_URL;
+
+    switch (request.method) {
+      case "POST": {
+        return await followAccount(
+          basePath,
+          token,
+          formData.get("accountName") as string
+        );
+      }
+      case "DELETE": {
+        return await unfollowAccount(
+          basePath,
+          token,
+          formData.get("accountName") as string
+        );
+      }
+    }
+  } catch (e) {
+    console.error(e);
+    return { error: "something went wrong" };
+  }
+};

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -3,11 +3,11 @@ import { followAccount, unfollowAccount } from "~/lib/api/follow";
 import { getToken } from "~/lib/api/getToken";
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
-  const isLoggedIn = await getToken(request);
-  if (!isLoggedIn.isLoggedIn) {
+  const auth = await getToken(request);
+  if (!auth.isLoggedIn) {
     return { error: "unauthorized" };
   }
-  const token = isLoggedIn.token;
+  const token = auth.token;
 
   try {
     const formData = await request.formData();

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -29,7 +29,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
       }
       default: {
-        return { error: "method not allowed"}
+        return { error: "method not allowed" };
       }
     }
   } catch (e) {


### PR DESCRIPTION
## 概要
- アカウントページにフォロー/フォロー解除ボタンを設置
  - フォローリクエスト中の判定はバックエンドが常にfalseを返すので一時的ににデッドコードになっています

