### PR TITLE
ci: Specify merge_group trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
マージキューを導入するため, ビルド CI に merge_group の指定を追加します.