### PR TITLE
fix: メール検証URLのアカウント名をエンコードする

### DIFF
--- a/app/routes/signup.verify.tsx
+++ b/app/routes/signup.verify.tsx
@@ -1,6 +1,9 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 
+const ACCOUNT_NAME_PATTERN =
+  /^@[A-Za-z0-9][A-Za-z0-9_.-]*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+
 export const loader = async ({
   request,
   context,
@@ -14,6 +17,14 @@ export const loader = async ({
       error: "Token or Account name not set",
     };
   }
+  if (
+    accountName.length < 8 ||
+    accountName.length > 512 ||
+    !ACCOUNT_NAME_PATTERN.test(accountName)
+  ) {
+    throw new Response("Invalid account name", { status: 400 });
+  }
+
   try {
     const basePath = (context.cloudflare.env as Env).API_BASE_URL;
     const res = await fetch(

--- a/app/routes/signup.verify.tsx
+++ b/app/routes/signup.verify.tsx
@@ -1,9 +1,6 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 
-const ACCOUNT_NAME_PATTERN =
-  /^@[A-Za-z0-9][A-Za-z0-9_.-]*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
-
 export const loader = async ({
   request,
   context,
@@ -17,18 +14,17 @@ export const loader = async ({
       error: "Token or Account name not set",
     };
   }
-  if (
-    accountName.length < 8 ||
-    accountName.length > 512 ||
-    !ACCOUNT_NAME_PATTERN.test(accountName)
-  ) {
+  if (accountName.length > 64) {
     throw new Response("Invalid account name", { status: 400 });
   }
 
   try {
     const basePath = (context.cloudflare.env as Env).API_BASE_URL;
     const res = await fetch(
-      new URL(`/v0/accounts/${accountName}/verify_email`, basePath),
+      new URL(
+        `/v0/accounts/${encodeURIComponent(accountName)}/verify_email`,
+        basePath
+      ),
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
close #777

- アカウント名をURLのパスに埋め込む際にエンコードするようにしました
- APIの仕様に合わせて64文字を上限にしています