### PR TITLE
fix(security): api エンドポイントで Origin を検証する

### DIFF
--- a/app/lib/checkOrigin.ts
+++ b/app/lib/checkOrigin.ts
@@ -22,8 +22,9 @@ export const checkOrigin = (request: Request): boolean => {
   }
 };
 
-export const forbiddenResponse = (): Response =>
-  new Response(FORBIDDEN_RESPONSE, {
+export const throwForbiddenResponse = (): never => {
+  throw new Response(FORBIDDEN_RESPONSE, {
     status: 403,
     headers: { "Content-Type": "application/json" },
   });
+};

--- a/app/lib/checkOrigin.ts
+++ b/app/lib/checkOrigin.ts
@@ -1,0 +1,29 @@
+const FORBIDDEN_RESPONSE = JSON.stringify({ error: "forbidden" });
+
+/**
+ * Check the browser's fetch metadata before handling a cookie-authenticated
+ * state-changing request.
+ */
+export const checkOrigin = (request: Request): boolean => {
+  const originHeader = request.headers.get("Origin");
+  if (!originHeader || originHeader === "null") {
+    return false;
+  }
+
+  const fetchSite = request.headers.get("Sec-Fetch-Site");
+  if (fetchSite && fetchSite !== "same-origin") {
+    return false;
+  }
+
+  try {
+    return new URL(originHeader).origin === new URL(request.url).origin;
+  } catch {
+    return false;
+  }
+};
+
+export const forbiddenResponse = (): Response =>
+  new Response(FORBIDDEN_RESPONSE, {
+    status: 403,
+    headers: { "Content-Type": "application/json" },
+  });

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -2,8 +2,13 @@ import type { ActionFunctionArgs } from "react-router";
 
 import { followAccount, unfollowAccount } from "~/lib/api/follow";
 import { getToken } from "~/lib/api/getToken";
+import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
+  if (!checkOrigin(request)) {
+    return forbiddenResponse();
+  }
+
   const auth = await getToken(request);
   if (!auth.isLoggedIn) {
     return { error: "unauthorized" };

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -2,11 +2,11 @@ import type { ActionFunctionArgs } from "react-router";
 
 import { followAccount, unfollowAccount } from "~/lib/api/follow";
 import { getToken } from "~/lib/api/getToken";
-import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
+import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
   if (!checkOrigin(request)) {
-    return forbiddenResponse();
+    throwForbiddenResponse();
   }
 
   const auth = await getToken(request);

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,16 +1,16 @@
 import type { ActionFunctionArgs } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
-import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
+import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({
   request,
   context,
 }: ActionFunctionArgs): Promise<
-  { status: "error"; message: string } | { status: "ok" } | Response
+  { status: "error"; message: string } | { status: "ok" }
 > => {
   if (!checkOrigin(request)) {
-    return forbiddenResponse();
+    throwForbiddenResponse();
   }
 
   const isLoggedIn = await getToken(request);

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,13 +1,18 @@
 import type { ActionFunctionArgs } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
+import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({
   request,
   context,
 }: ActionFunctionArgs): Promise<
-  { status: "error"; message: string } | { status: "ok" }
+  { status: "error"; message: string } | { status: "ok" } | Response
 > => {
+  if (!checkOrigin(request)) {
+    return forbiddenResponse();
+  }
+
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
     return { status: "error", message: "unauthorized" };

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -1,16 +1,14 @@
 import type { ActionFunctionArgs } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
-import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
+import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({
   request,
   context,
-}: ActionFunctionArgs): Promise<
-  { error: string } | { status: string } | Response
-> => {
+}: ActionFunctionArgs): Promise<{ error: string } | { status: string }> => {
   if (!checkOrigin(request)) {
-    return forbiddenResponse();
+    throwForbiddenResponse();
   }
 
   const isLoggedIn = await getToken(request);

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -1,11 +1,18 @@
 import type { ActionFunctionArgs } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
+import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({
   request,
   context,
-}: ActionFunctionArgs): Promise<{ error: string } | { status: string }> => {
+}: ActionFunctionArgs): Promise<
+  { error: string } | { status: string } | Response
+> => {
+  if (!checkOrigin(request)) {
+    return forbiddenResponse();
+  }
+
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
     return { error: "unauthorized" };

--- a/app/routes/api.renote.ts
+++ b/app/routes/api.renote.ts
@@ -2,16 +2,14 @@ import type { ActionFunctionArgs } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { renote } from "~/lib/api/renote";
-import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
+import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({
   request,
   context,
-}: ActionFunctionArgs): Promise<
-  { error: string } | { status: string } | Response
-> => {
+}: ActionFunctionArgs): Promise<{ error: string } | { status: string }> => {
   if (!checkOrigin(request)) {
-    return forbiddenResponse();
+    throwForbiddenResponse();
   }
 
   const isLoggedIn = await getToken(request);

--- a/app/routes/api.renote.ts
+++ b/app/routes/api.renote.ts
@@ -2,11 +2,18 @@ import type { ActionFunctionArgs } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { renote } from "~/lib/api/renote";
+import { checkOrigin, forbiddenResponse } from "~/lib/checkOrigin";
 
 export const action = async ({
   request,
   context,
-}: ActionFunctionArgs): Promise<{ error: string } | { status: string }> => {
+}: ActionFunctionArgs): Promise<
+  { error: string } | { status: string } | Response
+> => {
+  if (!checkOrigin(request)) {
+    return forbiddenResponse();
+  }
+
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
     return { error: "unauthorized" };

--- a/tests/csrf.spec.ts
+++ b/tests/csrf.spec.ts
@@ -19,3 +19,23 @@ test("rejects cross-origin state-changing requests", async ({ request }) => {
     expect(response.status(), endpoint).toBe(403);
   }
 });
+
+test("allows same-origin state-changing requests", async ({ request }) => {
+  const endpoints = [
+    "/api/follow",
+    "/api/notes",
+    "/api/reaction",
+    "/api/renote",
+  ];
+
+  for (const endpoint of endpoints) {
+    const response = await request.post(endpoint, {
+      headers: {
+        Origin: "http://localhost:5173",
+        "Sec-Fetch-Site": "same-origin",
+      },
+    });
+
+    expect(response.status(), endpoint).not.toBe(403);
+  }
+});

--- a/tests/csrf.spec.ts
+++ b/tests/csrf.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test("rejects cross-origin state-changing requests", async ({ request }) => {
+  const endpoints = [
+    "/api/follow",
+    "/api/notes",
+    "/api/reaction",
+    "/api/renote",
+  ];
+
+  for (const endpoint of endpoints) {
+    const response = await request.post(endpoint, {
+      headers: {
+        Origin: "https://attacker.example",
+        "Sec-Fetch-Site": "cross-site",
+      },
+    });
+
+    expect(response.status(), endpoint).toBe(403);
+  }
+});


### PR DESCRIPTION
close #776

- cookie認証を受け取るAPIでOriginを検証するようにしました
  - `/api/follow`、`/api/notes`、`/api/reaction`、`/api/renote`
  - Originが一致しないリクエストは403を返します
- クロスオリジンを拒否し、同一オリジンを許可するE2Eテストを追加しました
