### PR TITLE
fix: APIルートが返すステータスコードを見直し

### DIFF
--- a/app/routes/accounts.$id._index.tsx
+++ b/app/routes/accounts.$id._index.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
-import { useLoaderData } from "react-router";
+import { data, useLoaderData } from "react-router";
 
 import { EmptyState } from "~/components/emptyState";
 import { FollowButton } from "~/components/followButton";
@@ -55,7 +55,9 @@ export const loader = async ({
   const beforeID = query.get("before_id") ?? undefined;
   const afterID = query.get("after_id") ?? undefined;
   if (beforeID && afterID) {
-    throw new Error("before_id and after_id cannot be used together");
+    throw data("before_id and after_id cannot be used together", {
+      status: 400,
+    });
   }
 
   const timelineRes = await accountTimeline(

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -1,4 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
 
 import { followAccount, unfollowAccount } from "~/lib/api/follow";
 import { getToken } from "~/lib/api/getToken";
@@ -12,7 +13,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const auth = await getToken(request);
   if (!auth.isLoggedIn) {
-    return { error: "unauthorized" };
+    return data({ error: "unauthorized" }, { status: 401 });
   }
   const token = auth.token;
 

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { data } from "react-router";
+import { redirect } from "react-router";
 
 import { followAccount, unfollowAccount } from "~/lib/api/follow";
 import { getToken } from "~/lib/api/getToken";
@@ -13,7 +13,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const auth = await getToken(request);
   if (!auth.isLoggedIn) {
-    throw data({ error: "unauthorized" }, { status: 401 });
+    throw redirect("/login");
   }
   const token = auth.token;
 

--- a/app/routes/api.follow.ts
+++ b/app/routes/api.follow.ts
@@ -13,7 +13,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const auth = await getToken(request);
   if (!auth.isLoggedIn) {
-    return data({ error: "unauthorized" }, { status: 401 });
+    throw data({ error: "unauthorized" }, { status: 401 });
   }
   const token = auth.token;
 

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -5,12 +5,7 @@ import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 import { cloudflareContext } from "~/lib/cloudflareContext";
 
-export const action = async ({
-  request,
-  context,
-}: ActionFunctionArgs): Promise<
-  Response | { status: "error"; message: string } | { status: "ok" }
-> => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   if (!checkOrigin(request)) {
     throwForbiddenResponse();
   }

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -12,7 +12,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    return data({ status: "error", message: "unauthorized" }, { status: 401 });
+    throw data({ status: "error", message: "unauthorized" }, { status: 401 });
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { data } from "react-router";
+import { redirect } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
@@ -12,7 +12,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    throw data({ status: "error", message: "unauthorized" }, { status: 401 });
+    throw redirect("/login");
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,4 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
@@ -8,7 +9,7 @@ export const action = async ({
   request,
   context,
 }: ActionFunctionArgs): Promise<
-  { status: "error"; message: string } | { status: "ok" }
+  Response | { status: "error"; message: string } | { status: "ok" }
 > => {
   if (!checkOrigin(request)) {
     throwForbiddenResponse();
@@ -16,7 +17,7 @@ export const action = async ({
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    return { status: "error", message: "unauthorized" };
+    return data({ status: "error", message: "unauthorized" }, { status: 401 });
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -12,7 +12,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    return data({ error: "unauthorized" }, { status: 401 });
+    throw data({ error: "unauthorized" }, { status: 401 });
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -5,12 +5,7 @@ import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 import { cloudflareContext } from "~/lib/cloudflareContext";
 
-export const action = async ({
-  request,
-  context,
-}: ActionFunctionArgs): Promise<
-  Response | { error: string } | { status: string }
-> => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   if (!checkOrigin(request)) {
     throwForbiddenResponse();
   }

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { data } from "react-router";
+import { redirect } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
@@ -12,7 +12,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    throw data({ error: "unauthorized" }, { status: 401 });
+    throw redirect("/login");
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -1,4 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
@@ -7,14 +8,16 @@ import { cloudflareContext } from "~/lib/cloudflareContext";
 export const action = async ({
   request,
   context,
-}: ActionFunctionArgs): Promise<{ error: string } | { status: string }> => {
+}: ActionFunctionArgs): Promise<
+  Response | { error: string } | { status: string }
+> => {
   if (!checkOrigin(request)) {
     throwForbiddenResponse();
   }
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    return { error: "unauthorized" };
+    return data({ error: "unauthorized" }, { status: 401 });
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.renote.ts
+++ b/app/routes/api.renote.ts
@@ -13,7 +13,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    return data({ error: "unauthorized" }, { status: 401 });
+    throw data({ error: "unauthorized" }, { status: 401 });
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.renote.ts
+++ b/app/routes/api.renote.ts
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
-import { data } from "react-router";
+import { redirect } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { renote } from "~/lib/api/renote";
@@ -13,7 +13,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    throw data({ error: "unauthorized" }, { status: 401 });
+    throw redirect("/login");
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/api.renote.ts
+++ b/app/routes/api.renote.ts
@@ -6,12 +6,7 @@ import { renote } from "~/lib/api/renote";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 import { cloudflareContext } from "~/lib/cloudflareContext";
 
-export const action = async ({
-  request,
-  context,
-}: ActionFunctionArgs): Promise<
-  Response | { error: string } | { status: string }
-> => {
+export const action = async ({ request, context }: ActionFunctionArgs) => {
   if (!checkOrigin(request)) {
     throwForbiddenResponse();
   }

--- a/app/routes/api.renote.ts
+++ b/app/routes/api.renote.ts
@@ -1,4 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
 
 import { getToken } from "~/lib/api/getToken";
 import { renote } from "~/lib/api/renote";
@@ -8,14 +9,16 @@ import { cloudflareContext } from "~/lib/cloudflareContext";
 export const action = async ({
   request,
   context,
-}: ActionFunctionArgs): Promise<{ error: string } | { status: string }> => {
+}: ActionFunctionArgs): Promise<
+  Response | { error: string } | { status: string }
+> => {
   if (!checkOrigin(request)) {
     throwForbiddenResponse();
   }
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    return { error: "unauthorized" };
+    return data({ error: "unauthorized" }, { status: 401 });
   }
   const token = isLoggedIn.token;
 


### PR DESCRIPTION
close #781 

## 概要
- 認証が必要なAPIルートで、ログインしていなくても200が返る問題の修正
- 未ログイン状態でAPIルートを叩くとログインページにリダイレクトするように
- アカウントタイムラインで、`before_id`/`after_id`を同時指定した場合に400を返すように

### 追加情報
- react routeの`data`関数を使うと`Response`を関数の返値の型に追加する必要があったため、型推論に任せて返値の型は削除しました
  - #780 / #782 周りで再考します