### PR TITLE
refactor: exp-api-typesのクライアントを使うように変更

### DIFF
--- a/app/lib/account.ts
+++ b/app/lib/account.ts
@@ -1,4 +1,11 @@
+import {
+  getV0AccountsIdentifier,
+  getV0TimelineAccountsId,
+} from "@pulsate-dev/exp-api-types";
+
 import type { TimelineResponse } from "~/lib/api/timeline";
+
+import { apiOptions, parseApiErrorMessage } from "./api/client";
 
 export interface AccountResponse {
   id: string;
@@ -18,15 +25,24 @@ export const account = async (
   basePath: string
 ): Promise<AccountResponse | { error: string }> => {
   try {
-    const res = await fetch(new URL(`/v0/accounts/${identifier}`, basePath), {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+    const { data, error } = await getV0AccountsIdentifier({
+      ...apiOptions(basePath, token),
+      path: { identifier },
     });
-    if (!res.ok) {
-      return { error: "failed to fetch" };
+    if (error || !data) {
+      return { error: error ? parseApiErrorMessage(error) : "failed to fetch" };
     }
-    return (await res.json()) as AccountResponse;
+    return {
+      id: data.id,
+      name: data.name,
+      nickname: data.nickname,
+      bio: data.bio,
+      avatar: data.avatar,
+      header: data.header,
+      followed_count: data.followed_count,
+      following_count: data.following_count,
+      note_count: data.note_count,
+    };
   } catch {
     return { error: "unknown error" };
   }
@@ -39,20 +55,22 @@ export const accountTimeline = async (
   beforeID?: string
 ): Promise<TimelineResponse[] | { error: string }> => {
   try {
-    const url = new URL(`/v0/timeline/accounts/${id}`, basePath);
-    if (beforeID) {
-      url.searchParams.append("before_id", beforeID);
-    }
-
-    const res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+    const { data, error } = await getV0TimelineAccountsId({
+      ...apiOptions(basePath, token),
+      path: { id },
+      query: beforeID ? { before_id: beforeID } : undefined,
     });
-    if (!res.ok) {
-      return (await res.json()) as { error: string };
+    if (error || !data) {
+      return { error: parseApiErrorMessage(error) };
     }
-    return (await res.json()) as TimelineResponse[];
+    return data.map(
+      (note) =>
+        ({
+          ...note,
+          created_at: new Date(note.created_at),
+          visibility: note.visibility as TimelineResponse["visibility"],
+        }) satisfies TimelineResponse
+    );
   } catch {
     return { error: "unknown error" };
   }

--- a/app/lib/account.ts
+++ b/app/lib/account.ts
@@ -26,7 +26,11 @@ export const account = async (
 ): Promise<AccountResponse | { error: string }> => {
   try {
     const { data, error } = await getV0AccountsIdentifier({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(identifier)}`
+      ),
       path: { identifier },
     });
     if (error || !data) {
@@ -56,7 +60,11 @@ export const accountTimeline = async (
 ): Promise<TimelineResponse[] | { error: string }> => {
   try {
     const { data, error } = await getV0TimelineAccountsId({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/timeline/accounts/${encodeURIComponent(id)}`
+      ),
       path: { id },
       query: beforeID ? { before_id: beforeID } : undefined,
     });

--- a/app/lib/api/account.ts
+++ b/app/lib/api/account.ts
@@ -36,7 +36,11 @@ export const account = async (
       error,
       response: rawResponse,
     } = await getV0AccountsIdentifier({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(identifier)}`
+      ),
       path: { identifier },
     });
     if (error || !response) {
@@ -74,7 +78,11 @@ export const accountTimeline = async (
 ): Promise<TimelineResponse[] | { error: string }> => {
   try {
     const { data: response, error } = await getV0TimelineAccountsId({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/timeline/accounts/${encodeURIComponent(id)}`
+      ),
       path: { id },
       query: beforeID ? { before_id: beforeID } : undefined,
     });
@@ -127,7 +135,11 @@ export const updateAccount = async (
     };
 
     const { data, error, response } = await patchV0AccountsName({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(name)}`
+      ),
       body,
       path: { name },
     });

--- a/app/lib/api/account.ts
+++ b/app/lib/api/account.ts
@@ -1,13 +1,17 @@
 import type {
-  GetV0AccountsIdentifierResponse,
-  GetV0TimelineAccountsIdResponse,
   UpdateAccountRequest,
   UpdateAccountResponse,
+} from "@pulsate-dev/exp-api-types";
+import {
+  getV0AccountsIdentifier,
+  getV0TimelineAccountsId,
+  patchV0AccountsName,
 } from "@pulsate-dev/exp-api-types";
 
 import type { TimelineResponse } from "~/lib/api/timeline";
 
 import { logger } from "../logger";
+import { apiOptions, parseApiErrorMessage } from "./client";
 
 export interface AccountResponse {
   id: string;
@@ -27,13 +31,16 @@ export const account = async (
   basePath: string
 ): Promise<AccountResponse | { error: string }> => {
   try {
-    const res = await fetch(new URL(`/v0/accounts/${identifier}`, basePath), {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+    const {
+      data: response,
+      error,
+      response: rawResponse,
+    } = await getV0AccountsIdentifier({
+      ...apiOptions(basePath, token),
+      path: { identifier },
     });
-    if (!res.ok) {
-      switch (res.status) {
+    if (error || !response) {
+      switch (rawResponse?.status) {
         case 500:
           return { error: "internal server error" };
         case 404:
@@ -43,18 +50,16 @@ export const account = async (
       }
     }
 
-    const repsonse = (await res.json()) as GetV0AccountsIdentifierResponse;
-
     return {
-      id: repsonse.id,
-      name: repsonse.name,
-      nickname: repsonse.nickname,
-      bio: repsonse.bio,
-      avatar: repsonse.avatar,
-      header: repsonse.header,
-      followed_count: repsonse.followed_count,
-      following_count: repsonse.following_count,
-      note_count: repsonse.note_count,
+      id: response.id,
+      name: response.name,
+      nickname: response.nickname,
+      bio: response.bio,
+      avatar: response.avatar,
+      header: response.header,
+      followed_count: response.followed_count,
+      following_count: response.following_count,
+      note_count: response.note_count,
     } satisfies AccountResponse;
   } catch {
     return { error: "unknown error" };
@@ -68,21 +73,14 @@ export const accountTimeline = async (
   beforeID?: string
 ): Promise<TimelineResponse[] | { error: string }> => {
   try {
-    const url = new URL(`/v0/timeline/accounts/${id}`, basePath);
-    if (beforeID) {
-      url.searchParams.append("before_id", beforeID);
-    }
-
-    const res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+    const { data: response, error } = await getV0TimelineAccountsId({
+      ...apiOptions(basePath, token),
+      path: { id },
+      query: beforeID ? { before_id: beforeID } : undefined,
     });
-    if (!res.ok) {
-      return (await res.json()) as { error: string };
+    if (error || !response) {
+      return { error: parseApiErrorMessage(error) };
     }
-
-    const response = (await res.json()) as GetV0TimelineAccountsIdResponse;
 
     return response.map(
       (item) =>
@@ -128,17 +126,13 @@ export const updateAccount = async (
       nickname,
     };
 
-    const res = await fetch(new URL(`/v0/accounts/${name}`, basePath), {
-      method: "PATCH",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
+    const { data, error, response } = await patchV0AccountsName({
+      ...apiOptions(basePath, token),
+      body,
+      path: { name },
     });
-
-    if (!res.ok) {
-      switch (res.status) {
+    if (error || !data) {
+      switch (response?.status) {
         case 400:
           return { error: "invalid request" };
         case 404:
@@ -150,7 +144,7 @@ export const updateAccount = async (
       }
     }
 
-    return (await res.json()) as UpdateAccountResponse;
+    return data;
   } catch (e) {
     logger.error("Unexpected Error:", e);
     return { error: "unknown error" };

--- a/app/lib/api/client.ts
+++ b/app/lib/api/client.ts
@@ -1,7 +1,8 @@
-export const apiOptions = (baseUrl: string, token?: string) => ({
+export const apiOptions = (baseUrl: string, token?: string, url?: string) => ({
   baseUrl,
   headers: token ? { Authorization: `Bearer ${token}` } : undefined,
   signal: AbortSignal.timeout(10_000),
+  ...(url ? { url } : {}),
 });
 
 export const parseApiErrorMessage = (error: unknown): string => {

--- a/app/lib/api/client.ts
+++ b/app/lib/api/client.ts
@@ -1,0 +1,10 @@
+export const apiOptions = (baseUrl: string, token?: string) => ({
+  baseUrl,
+  headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  signal: AbortSignal.timeout(10_000),
+});
+
+export const parseApiErrorMessage = (error: unknown): string => {
+  const message = (error as { error?: unknown } | null | undefined)?.error;
+  return typeof message === "string" ? message : "unknown error";
+};

--- a/app/lib/api/follow.ts
+++ b/app/lib/api/follow.ts
@@ -1,4 +1,10 @@
+import {
+  deleteV0AccountsNameFollow,
+  postV0AccountsNameFollow,
+} from "@pulsate-dev/exp-api-types";
+
 import { logger } from "../logger";
+import { apiOptions } from "./client";
 
 export async function followAccount(
   basePath: string,
@@ -6,16 +12,11 @@ export async function followAccount(
   accountName: string
 ): Promise<{ isSuccess: boolean }> {
   try {
-    const followRes = await fetch(
-      new URL(`/v0/accounts/${accountName}/follow`, basePath),
-      {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    if (!followRes.ok) {
+    const { error } = await postV0AccountsNameFollow({
+      ...apiOptions(basePath, token),
+      path: { name: accountName },
+    });
+    if (error) {
       return { isSuccess: false };
     }
   } catch (e) {
@@ -32,20 +33,14 @@ export async function unfollowAccount(
   accountName: string
 ): Promise<{ isSuccess: boolean }> {
   try {
-    const followRes = await fetch(
-      new URL(`/v0/accounts/${accountName}/follow`, basePath),
-      {
-        method: "DELETE",
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    if (followRes.status !== 204) {
-      logger.error("Unexpected Error:", { response: await followRes.text() });
+    const { error } = await deleteV0AccountsNameFollow({
+      ...apiOptions(basePath, token),
+      path: { name: accountName },
+    });
+    if (error) {
+      logger.error("Unexpected Error:", error);
       return { isSuccess: false };
     }
-    logger.error("Succeed to follow:", accountName);
   } catch (e) {
     logger.error("Unexpected Error:", e);
     return { isSuccess: false };

--- a/app/lib/api/follow.ts
+++ b/app/lib/api/follow.ts
@@ -13,7 +13,11 @@ export async function followAccount(
 ): Promise<{ isSuccess: boolean }> {
   try {
     const { error } = await postV0AccountsNameFollow({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(accountName)}/follow`
+      ),
       path: { name: accountName },
     });
     if (error) {
@@ -34,7 +38,11 @@ export async function unfollowAccount(
 ): Promise<{ isSuccess: boolean }> {
   try {
     const { error } = await deleteV0AccountsNameFollow({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(accountName)}/follow`
+      ),
       path: { name: accountName },
     });
     if (error) {

--- a/app/lib/api/followlist.ts
+++ b/app/lib/api/followlist.ts
@@ -25,7 +25,11 @@ export async function getFollowingList(
 > {
   try {
     const { data: accounts, error } = await getV0AccountsIdFollowing({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(accountID)}/following`
+      ),
       path: { id: accountID },
     });
     if (error || !accounts) {
@@ -55,7 +59,11 @@ export async function getFollowersList(
 > {
   try {
     const { data: accounts, error } = await getV0AccountsIdFollower({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(accountID)}/follower`
+      ),
       path: { id: accountID },
     });
     if (error || !accounts) {

--- a/app/lib/api/followlist.ts
+++ b/app/lib/api/followlist.ts
@@ -1,9 +1,10 @@
-import type {
-  GetV0AccountsIdFollowerResponse,
-  GetV0AccountsIdFollowingResponse,
+import {
+  getV0AccountsIdFollower,
+  getV0AccountsIdFollowing,
 } from "@pulsate-dev/exp-api-types";
 
 import { logger } from "../logger";
+import { apiOptions } from "./client";
 
 interface FollowResponseBase {
   id: string;
@@ -23,20 +24,13 @@ export async function getFollowingList(
   { isSuccess: true; response: FollowingResponse[] } | { isSuccess: false }
 > {
   try {
-    const followingRes = await fetch(
-      new URL(`/v0/accounts/${accountID}/following`, basePath),
-      {
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    if (!followingRes.ok) {
+    const { data: accounts, error } = await getV0AccountsIdFollowing({
+      ...apiOptions(basePath, token),
+      path: { id: accountID },
+    });
+    if (error || !accounts) {
       return { isSuccess: false };
     }
-
-    const accounts =
-      (await followingRes.json()) as GetV0AccountsIdFollowingResponse;
 
     return {
       isSuccess: true,
@@ -60,20 +54,13 @@ export async function getFollowersList(
   { isSuccess: true; response: FollowerResponse[] } | { isSuccess: false }
 > {
   try {
-    const followerRes = await fetch(
-      new URL(`/v0/accounts/${accountID}/follower`, basePath),
-      {
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    if (!followerRes.ok) {
+    const { data: accounts, error } = await getV0AccountsIdFollower({
+      ...apiOptions(basePath, token),
+      path: { id: accountID },
+    });
+    if (error || !accounts) {
       return { isSuccess: false };
     }
-
-    const accounts =
-      (await followerRes.json()) as GetV0AccountsIdFollowerResponse;
 
     return {
       isSuccess: true,

--- a/app/lib/api/login.ts
+++ b/app/lib/api/login.ts
@@ -1,10 +1,8 @@
-import type {
-  PostV0LoginError,
-  PostV0LoginResponse,
-} from "@pulsate-dev/exp-api-types";
+import { postV0Login } from "@pulsate-dev/exp-api-types";
 import { createCookie } from "react-router";
 
 import { logger } from "../logger";
+import { apiOptions } from "./client";
 
 export type LoginArgs = {
   email: string;
@@ -23,25 +21,21 @@ export const login = async (
     }
 > => {
   try {
-    const response = await fetch(new URL("/v0/login", basePath), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ email, passphrase, captcha_token: "" }),
+    const {
+      data: res,
+      error,
+      response,
+    } = await postV0Login({
+      ...apiOptions(basePath),
+      body: { email, passphrase, captcha_token: "" },
     });
-
-    if (!response.ok) {
-      if (response.status === 400) {
+    if (error || !res) {
+      if (response?.status === 400) {
         return { error: "INVALID_CREDENTIALS" };
       }
-      logger.error("Unexpected Error:", await response.text());
+      logger.error("Unexpected Error:", error);
       return { error: "CONNECTION_FAILED" };
     }
-
-    const res = (await response.json()) as
-      | PostV0LoginError
-      | PostV0LoginResponse;
 
     if (!("authorization_token" in res)) {
       logger.error(

--- a/app/lib/api/note.ts
+++ b/app/lib/api/note.ts
@@ -1,6 +1,9 @@
+import { getV0NotesId } from "@pulsate-dev/exp-api-types";
+
 import type { TimelineResponse } from "~/lib/api/timeline";
 
 import { logger } from "../logger";
+import { apiOptions, parseApiErrorMessage } from "./client";
 
 export const fetchNote = async (
   token: string,
@@ -8,17 +11,19 @@ export const fetchNote = async (
   noteID: string
 ): Promise<TimelineResponse | { error: string }> => {
   try {
-    const res = await fetch(new URL(`/v0/notes/${noteID}`, basePath), {
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
+    const { data: note, error } = await getV0NotesId({
+      ...apiOptions(basePath, token),
+      path: { id: noteID },
     });
-    if (!res.ok) {
-      const json = await res.json();
-      logger.error("Fetch notes error:", json);
-      return json as { error: string };
+    if (error || !note) {
+      logger.error("Fetch notes error:", error);
+      return { error: parseApiErrorMessage(error) };
     }
-    return (await res.json()) as TimelineResponse;
+    return {
+      ...note,
+      created_at: new Date(note.created_at),
+      visibility: note.visibility as TimelineResponse["visibility"],
+    };
   } catch (e) {
     logger.error("Unexpected Error:", e);
     return { error: "unknown error" };

--- a/app/lib/api/note.ts
+++ b/app/lib/api/note.ts
@@ -12,7 +12,7 @@ export const fetchNote = async (
 ): Promise<TimelineResponse | { error: string }> => {
   try {
     const { data: note, error } = await getV0NotesId({
-      ...apiOptions(basePath, token),
+      ...apiOptions(basePath, token, `/v0/notes/${encodeURIComponent(noteID)}`),
       path: { id: noteID },
     });
     if (error || !note) {

--- a/app/lib/api/relationship.ts
+++ b/app/lib/api/relationship.ts
@@ -1,4 +1,7 @@
+import { getV0AccountsIdRelationships } from "@pulsate-dev/exp-api-types";
+
 import { logger } from "../logger";
+import { apiOptions } from "./client";
 
 export interface AccountRelationshipResponse {
   id: string;
@@ -16,25 +19,13 @@ export async function accountRelationship(
   | { isSuccess: false }
 > {
   try {
-    const relationshipRes = await fetch(
-      new URL(`/v0/accounts/${accountID}/relationships`, basePath),
-      {
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    if (!relationshipRes.ok) {
+    const { data: relationship, error } = await getV0AccountsIdRelationships({
+      ...apiOptions(basePath, token),
+      path: { id: accountID },
+    });
+    if (error || !relationship) {
       return { isSuccess: false };
     }
-
-    // ToDo: exp-api-typesの型を使う
-    const relationship = (await relationshipRes.json()) as {
-      id: string;
-      is_followed: boolean;
-      is_following: boolean;
-      is_follow_requesting: boolean;
-    };
 
     return {
       isSuccess: true,

--- a/app/lib/api/relationship.ts
+++ b/app/lib/api/relationship.ts
@@ -20,7 +20,11 @@ export async function accountRelationship(
 > {
   try {
     const { data: relationship, error } = await getV0AccountsIdRelationships({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/accounts/${encodeURIComponent(accountID)}/relationships`
+      ),
       path: { id: accountID },
     });
     if (error || !relationship) {

--- a/app/lib/api/renote.ts
+++ b/app/lib/api/renote.ts
@@ -18,7 +18,11 @@ export async function renote(
 ): Promise<{ isSuccess: boolean }> {
   try {
     const { error } = await postV0NotesIdRenote({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/notes/${encodeURIComponent(originalNoteID)}/renote`
+      ),
       body: args,
       path: { id: originalNoteID },
     });

--- a/app/lib/api/renote.ts
+++ b/app/lib/api/renote.ts
@@ -1,8 +1,11 @@
+import { postV0NotesIdRenote } from "@pulsate-dev/exp-api-types";
+
 import { logger } from "../logger";
+import { apiOptions } from "./client";
 
 export interface RenoteArgs {
   content: string;
-  visibility: "PUBLIC" | "HOME" | "FOLLOWERS";
+  visibility: "PUBLIC" | "HOME";
   attachment_file_ids: string[];
   contents_warning_comment: string;
 }
@@ -14,20 +17,13 @@ export async function renote(
   args: RenoteArgs
 ): Promise<{ isSuccess: boolean }> {
   try {
-    const res = await fetch(
-      new URL(`/v0/notes/${originalNoteID}/renote`, basePath),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(args),
-      }
-    );
-
-    if (!res.ok) {
-      logger.error("failed to renote", { args, response: await res.text() });
+    const { error } = await postV0NotesIdRenote({
+      ...apiOptions(basePath, token),
+      body: args,
+      path: { id: originalNoteID },
+    });
+    if (error) {
+      logger.error("failed to renote", { args, error });
       return { isSuccess: false };
     }
   } catch (e) {

--- a/app/lib/api/timeline.ts
+++ b/app/lib/api/timeline.ts
@@ -1,4 +1,7 @@
+import { getV0TimelineHome } from "@pulsate-dev/exp-api-types";
+
 import { logger } from "../logger";
+import { apiOptions, parseApiErrorMessage } from "./client";
 
 export interface TimelineResponse {
   id: string;
@@ -29,23 +32,24 @@ export const fetchHomeTimeline = async (
   beforeID?: string
 ): Promise<{ notes: TimelineResponse[] } | { error: string }> => {
   try {
-    const url = new URL("/v0/timeline/home", basePath);
-    if (beforeID) {
-      url.searchParams.append("before_id", beforeID);
-    }
-
-    const timelineRes = await fetch(url, {
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
+    const { data: notes, error } = await getV0TimelineHome({
+      ...apiOptions(basePath, token),
+      query: beforeID ? { before_id: beforeID } : undefined,
     });
-    if (!timelineRes.ok) {
-      const json = await timelineRes.json();
-      logger.error("Fetch home timeline error:", json);
-      return json as { error: string };
+    if (error || !notes) {
+      logger.error("Fetch home timeline error:", error);
+      return { error: parseApiErrorMessage(error) };
     }
-    const notes = (await timelineRes.json()) as TimelineResponse[];
-    return { notes };
+    return {
+      notes: notes.map(
+        (note) =>
+          ({
+            ...note,
+            created_at: new Date(note.created_at),
+            visibility: note.visibility as TimelineResponse["visibility"],
+          }) satisfies TimelineResponse
+      ),
+    };
   } catch (e) {
     logger.error("Unexpected Error:", e);
     return { error: "unknown error" };

--- a/app/routes/api.notes.ts
+++ b/app/routes/api.notes.ts
@@ -1,6 +1,8 @@
+import { postV0Notes } from "@pulsate-dev/exp-api-types";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
 
+import { apiOptions, parseApiErrorMessage } from "~/lib/api/client";
 import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 import { cloudflareContext } from "~/lib/cloudflareContext";
@@ -19,23 +21,18 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   try {
     const formData = await request.formData();
     const basePath = context.get(cloudflareContext).env.API_BASE_URL;
-    const res = await fetch(new URL("/v0/notes", basePath), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({
-        content: formData.get("content"),
-        visibility: formData.get("visibility"),
+    const { error } = await postV0Notes({
+      ...apiOptions(basePath, token),
+      body: {
+        content: formData.get("content") as string,
+        visibility: formData.get("visibility") as string,
         attachment_file_ids: [],
         contents_warning_comment: "",
-      }),
+      },
     });
 
-    if (!res.ok) {
-      const errorRes = (await res.json()) as { error: string };
-      return { status: "error", message: errorRes.error };
+    if (error) {
+      return { status: "error", message: parseApiErrorMessage(error) };
     }
 
     return { status: "ok" };

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -51,7 +51,11 @@ const reaction = async (
 ): Promise<{ status: string } | { error: string }> => {
   try {
     const { error } = await postV0NotesIdReaction({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/notes/${encodeURIComponent(noteID)}/reaction`
+      ),
       body: { emoji },
       path: { id: noteID },
     });
@@ -76,7 +80,11 @@ const undoReaction = async (
 ): Promise<{ status: string } | { error: string }> => {
   try {
     const { error } = await deleteV0NotesIdReaction({
-      ...apiOptions(basePath, token),
+      ...apiOptions(
+        basePath,
+        token,
+        `/v0/notes/${encodeURIComponent(noteID)}/reaction`
+      ),
       path: { id: noteID },
     });
 

--- a/app/routes/api.reaction.ts
+++ b/app/routes/api.reaction.ts
@@ -1,6 +1,11 @@
+import {
+  deleteV0NotesIdReaction,
+  postV0NotesIdReaction,
+} from "@pulsate-dev/exp-api-types";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
 
+import { apiOptions } from "~/lib/api/client";
 import { getToken } from "~/lib/api/getToken";
 import { checkOrigin, throwForbiddenResponse } from "~/lib/checkOrigin";
 import { cloudflareContext } from "~/lib/cloudflareContext";
@@ -45,16 +50,13 @@ const reaction = async (
   basePath: string
 ): Promise<{ status: string } | { error: string }> => {
   try {
-    const res = await fetch(new URL(`/v0/notes/${noteID}/reaction`, basePath), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ emoji }),
+    const { error } = await postV0NotesIdReaction({
+      ...apiOptions(basePath, token),
+      body: { emoji },
+      path: { id: noteID },
     });
 
-    if (!res.ok) {
+    if (error) {
       throw new Error("Failed to react");
     }
 
@@ -73,15 +75,12 @@ const undoReaction = async (
   basePath: string
 ): Promise<{ status: string } | { error: string }> => {
   try {
-    const res = await fetch(new URL(`/v0/notes/${noteID}/reaction`, basePath), {
-      method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+    const { error } = await deleteV0NotesIdReaction({
+      ...apiOptions(basePath, token),
+      path: { id: noteID },
     });
 
-    if (!res.ok) {
+    if (error) {
       throw new Error("Failed to undo reaction");
     }
 

--- a/app/routes/signup._index.tsx
+++ b/app/routes/signup._index.tsx
@@ -1,7 +1,9 @@
 import { Turnstile } from "@marsidev/react-turnstile";
+import { postV0Accounts } from "@pulsate-dev/exp-api-types";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { Form, Link, redirect, useLoaderData } from "react-router";
 
+import { apiOptions } from "~/lib/api/client";
 import { cloudflareContext } from "~/lib/cloudflareContext";
 
 import styles from "~/components/signup.module.css";
@@ -18,19 +20,16 @@ export const action = async ({
 
   try {
     const env = context.get(cloudflareContext).env;
-    const response = await fetch(new URL("/v0/accounts", env.API_BASE_URL), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    const { error } = await postV0Accounts({
+      ...apiOptions(env.API_BASE_URL),
+      body: {
         name: `@${name}@${env.INSTANCE_FQDN}`,
         email,
         passphrase,
-        captcha_token: turnstileToken,
-      }),
+        captcha_token: turnstileToken as string,
+      },
     });
-    if (!response.ok) {
+    if (error) {
       return { error: "Failed to create account" };
     }
 

--- a/app/routes/signup.verify.tsx
+++ b/app/routes/signup.verify.tsx
@@ -25,7 +25,11 @@ export const loader = async ({
   try {
     const basePath = context.get(cloudflareContext).env.API_BASE_URL;
     const { error, response } = await postV0AccountsNameVerifyEmail({
-      ...apiOptions(basePath),
+      ...apiOptions(
+        basePath,
+        undefined,
+        `/v0/accounts/${encodeURIComponent(accountName)}/verify_email`
+      ),
       body: { token },
       path: { name: accountName },
     });

--- a/app/routes/signup.verify.tsx
+++ b/app/routes/signup.verify.tsx
@@ -1,6 +1,8 @@
+import { postV0AccountsNameVerifyEmail } from "@pulsate-dev/exp-api-types";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
 
+import { apiOptions } from "~/lib/api/client";
 import { cloudflareContext } from "~/lib/cloudflareContext";
 
 export const loader = async ({
@@ -22,24 +24,14 @@ export const loader = async ({
 
   try {
     const basePath = context.get(cloudflareContext).env.API_BASE_URL;
-    const res = await fetch(
-      new URL(
-        `/v0/accounts/${encodeURIComponent(accountName)}/verify_email`,
-        basePath
-      ),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          token,
-        }),
-      }
-    );
+    const { error, response } = await postV0AccountsNameVerifyEmail({
+      ...apiOptions(basePath),
+      body: { token },
+      path: { name: accountName },
+    });
 
-    if (!res.ok) {
-      switch (res.status) {
+    if (error) {
+      switch (response?.status) {
         case 400:
           return { error: "Verification token is invalid." };
         case 404:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.13.3",
     "@marsidev/react-turnstile": "^1.3.1",
-    "@pulsate-dev/exp-api-types": "^0.0.1",
+    "@pulsate-dev/exp-api-types": "^0.1.2",
     "@react-router/cloudflare": "^8.0.0",
     "@react-router/fs-routes": "^8.0.0",
     "isbot": "^5.1.30",
@@ -50,7 +50,7 @@
     "postcss": "^8.5.6",
     "typescript": "^7.0.0",
     "vite": "catalog:",
-    "wrangler": "^4.68.0",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "wrangler": "^4.68.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pulsate-dev/exp-api-types':
-        specifier: ^0.0.1
-        version: 0.0.1
+        specifier: ^0.1.2
+        version: 0.1.2
       '@react-router/cloudflare':
         specifier: ^8.0.0
         version: 8.2.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
@@ -942,8 +942,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@pulsate-dev/exp-api-types@0.0.1':
-    resolution: {integrity: sha512-i4vlPyfKOXvKqrZnmVvPPrl3Bos2FlIEPaPInFCOPu7qQsc9fS9pCy3WPJiKr/s/KpIDfqT92Rchpe+g/gfRXQ==}
+  '@pulsate-dev/exp-api-types@0.1.2':
+    resolution: {integrity: sha512-Wv34PRbnwXeYlyfP/cWCv6ikISPKFrMWCrPVsriiaZGvTQ6YMHQb5bk4oMHL6eMmZ4VAL1DlyIztKBHMS900sA==}
 
   '@react-router/cloudflare@8.2.0':
     resolution: {integrity: sha512-jcVrAUys7IUaPRHheIa6usqBqTwfj/MwBLoLhPvaa91rX5K1yT+h21CP3uGW7oehFDXWH2JXNXPh5TuEBNcbRw==}
@@ -2995,7 +2995,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@pulsate-dev/exp-api-types@0.0.1': {}
+  '@pulsate-dev/exp-api-types@0.1.2': {}
 
   '@react-router/cloudflare@8.2.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)':
     dependencies:


### PR DESCRIPTION
close #780

## 概要

- APIを`@pulsate-dev/exp-api-types` Fetchクライアントへ移行
- ベースURL、認証ヘッダ、タイムアウトの設定を共通化
- クライアントから返ってくるエラーをパースして、既存のコードとの整合性を担保

