### PR TITLE
refactor: 認証エラー時のエラーハンドリングをredirectに統一する

### DIFF
--- a/app/routes/accounts.$id._index.tsx
+++ b/app/routes/accounts.$id._index.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
-import { data, useLoaderData } from "react-router";
+import { data, redirect, useLoaderData } from "react-router";
 
 import { EmptyState } from "~/components/emptyState";
 import { FollowButton } from "~/components/followButton";
@@ -40,7 +40,7 @@ export const loader = async ({
 
   const isLoggedIn = await getToken(request);
   if (!isLoggedIn.isLoggedIn) {
-    return { error: "not logged in" };
+    throw redirect("/login");
   }
   const token = isLoggedIn.token;
 
@@ -72,7 +72,7 @@ export const loader = async ({
 
   const loggedInAccountDatum = await loggedInAccount(request, basePath);
   if (!loggedInAccountDatum.isSuccess) {
-    return { error: "not logged in" };
+    throw redirect("/login");
   }
 
   const relationshipRes = await accountRelationship(

--- a/app/routes/accounts.$id.follower.tsx
+++ b/app/routes/accounts.$id.follower.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData, type LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, type LoaderFunctionArgs } from "react-router";
 
 import { FollowAccount } from "~/components/followAccount";
 import { account } from "~/lib/account";
@@ -17,7 +17,7 @@ export async function loader({
   const isLoggedIn = await getToken(request);
 
   if (!isLoggedIn.isLoggedIn) {
-    return { isSuccess: false };
+    throw redirect("/login");
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/accounts.$id.following.tsx
+++ b/app/routes/accounts.$id.following.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData, type LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, type LoaderFunctionArgs } from "react-router";
 
 import { FollowAccount } from "~/components/followAccount";
 import { account } from "~/lib/account";
@@ -17,7 +17,7 @@ export async function loader({
   const isLoggedIn = await getToken(request);
 
   if (!isLoggedIn.isLoggedIn) {
-    return { isSuccess: false };
+    throw redirect("/login");
   }
   const token = isLoggedIn.token;
 

--- a/app/routes/timeline.tsx
+++ b/app/routes/timeline.tsx
@@ -28,13 +28,12 @@ export const loader = async ({
       loggedInAccountID: string;
       originalNotes: TimelineResponse[];
     }
-  | Response
 > => {
   const basePath = context.get(cloudflareContext).env.API_BASE_URL;
 
   const cookie = await accountCookie.parse(request.headers.get("Cookie"));
   if (!cookie) {
-    return redirect("/login");
+    throw redirect("/login");
   }
 
   const query = new URL(request.url).searchParams;
@@ -46,7 +45,7 @@ export const loader = async ({
 
   const loggedInAccountDatum = await loggedInAccount(request, basePath);
   if (!loggedInAccountDatum.isSuccess) {
-    return { error: "not logged in" };
+    throw redirect("/login");
   }
 
   const renoteNotes = res.notes.filter((n) => n.original_note_id);


### PR DESCRIPTION

close #782 

## 概要
- 認証が必要な操作で、エラーレスポンスを返していたのを`throw redirect`に統一しました